### PR TITLE
preliminary date comparison methods 

### DIFF
--- a/src/undate/undate.py
+++ b/src/undate/undate.py
@@ -26,6 +26,9 @@ class DatePrecision(Enum):
     #: day
     DAY = auto()
 
+    def __str__(self):
+        return f"{self.name}"
+
 
 class Undate:
     """Simple object for representing uncertain, fuzzy or partially unknown dates"""
@@ -173,9 +176,20 @@ class Undate:
             return "<Undate '%s' (%s)>" % (self.label, self)
         return "<Undate %s>" % self
 
-    def __eq__(self, other: "Undate") -> bool:
+    def __eq__(self, other: Union["Undate", datetime.date]) -> bool:
         # question: should label be taken into account when checking equality?
         # for now, assuming label differences don't matter for comparing dates
+
+        # support comparison with datetime date ONLY for full day precision
+        if isinstance(other, datetime.date):
+            if self.precision == DatePrecision.DAY:
+                return self.earliest == other
+            else:
+                raise NotImplementedError(
+                    "Equality comparision with datetime.date not supported for %s precision"
+                    % self.precision
+                )
+
         return (
             self.earliest == other.earliest
             and self.latest == other.latest
@@ -185,6 +199,8 @@ class Undate:
             # internal format for comparison
             and self.initial_values == other.initial_values
         )
+
+    # def __lt__(self, other: "")
 
     @property
     def known_year(self) -> bool:

--- a/src/undate/undate.py
+++ b/src/undate/undate.py
@@ -225,6 +225,12 @@ class Undate:
             raise NotImplementedError(
                 "Can't compare when one date falls within the other"
             )
+        # NOTE: unsupported comparisons are supposed to return NotImplemented
+        # However, doing that in this case results in a confusing TypeError!
+        #   TypeError: '<' not supported between instances of 'Undate' and 'Undate'
+        # How to handle when the comparison is ambiguous / indeterminate?
+        # we may need a tribool / ternary type (true, false, unknown),
+        # but not sure what python builtin methods will do with it (unknown = false?)
 
         # for any other case (i.e., self == other), return false
         return False

--- a/src/undate/undate.py
+++ b/src/undate/undate.py
@@ -247,11 +247,9 @@ class Undate:
         return (
             self.earliest <= other.earliest
             and self.latest >= other.latest
-            # precision is not sufficient for comparing partially known dates
+            # is precision sufficient for comparing partially known dates?
             and self.precision > other.precision
         )
-        # TODO: how to compare partially unknown values
-        # like 19xx and 199x or 1801-XX and 1801-1X
 
     @property
     def known_year(self) -> bool:

--- a/tests/test_dateformat/test_base.py
+++ b/tests/test_dateformat/test_base.py
@@ -31,9 +31,12 @@ class TestBaseDateFormat:
             BaseDateFormat().to_string(1991)
 
 
-@pytest.mark.first
 def test_import_formatters_import_only_once(caplog):
-    # run first so we can confirm it runs once
+    # clear the cache, since any instantiation of an Undate
+    # object anywhere in the test suite will populate it
+    BaseDateFormat.import_formatters.cache_clear()
+
+    # run first, and confirm it runs and loads formatters
     with caplog.at_level(logging.DEBUG):
         import_count = BaseDateFormat.import_formatters()
     # should import at least one thing (iso8601)

--- a/tests/test_undate.py
+++ b/tests/test_undate.py
@@ -214,8 +214,6 @@ class TestUndate:
         (Undate(2022, 1, 1), Undate(2022)),
         (Undate(2022, 12, 31), Undate(2022)),
         (Undate(2022, 6, 15), Undate(2022, 6)),
-        # TODO: support partially known dates that are unambiguously in range
-        # (Undate("199X"), Undate("19XX")),
     ]
 
     @pytest.mark.parametrize("date1,date2", testdata_contains)
@@ -227,25 +225,22 @@ class TestUndate:
         (Undate(1980), Undate(2020)),
         (Undate(1980), Undate(2020, 6)),
         (Undate(1980, 6), Undate(2020, 6)),
+        # partially known dates that are similar but same precision,
+        # so one does not contain the other
+        (Undate("199X"), Undate("19XX")),
+        # - specific month to unknown month
+        (Undate(1980, 6), Undate(1980, "XX")),
+        # some of these might overlap, but we don't have enough
+        # information to determine
+        # - unknown month to unknown month
+        (Undate(1980, "XX"), Undate(1980, "XX")),
+        # - partially unknown month to unknown month
+        (Undate(1801, "1X"), Undate(1801, "XX")),
     ]
 
     @pytest.mark.parametrize("date1,date2", testdata_not_contains)
     def test_not_contains(self, date1, date2):
         assert date1 not in date2
-
-    def test_contains_ambiguous(self):
-        # date not in range due to precision
-        # TODO: can we return an unknown instead of false?
-        # or should this raise a not implemented error?
-
-        # these are cases where dates *might* overlap,
-        #  but we don't have enough information to determine
-        # - specific month to unknown month
-        assert Undate(1980, 6) not in Undate(1980, "XX")
-        # - unknown month to unknown month
-        assert Undate(1980, "XX") not in Undate(1980, "XX")
-        assert Undate(1980, 6) not in Undate(1980, "XX")
-        assert Undate(1801, "1X") not in Undate(1801, "XX")
 
     def test_sorting(self):
         # sorting should be possible based on gt/lt

--- a/tests/test_undate.py
+++ b/tests/test_undate.py
@@ -126,6 +126,11 @@ class TestUndate:
         with pytest.raises(ValueError):
             Undate(1990, 22)
 
+    def test_from_datetime_date(self):
+        undate_from_date = Undate.from_datetime_date(date(2001, 3, 5))
+        assert isinstance(undate_from_date, Undate)
+        assert undate_from_date == Undate(2001, 3, 5)
+
     def test_eq(self):
         assert Undate(2022) == Undate(2022)
         assert Undate(2022, 10) == Undate(2022, 10)
@@ -136,14 +141,11 @@ class TestUndate:
         # support comparisons with datetime objects for full day-precision
         assert Undate(2022, 10, 1) == date(2022, 10, 1)
         assert Undate(2022, 10, 1) != date(2022, 10, 2)
-        assert Undate(2022, 10, 1) != date(2021, 10, 1)
+        assert Undate(1980, 10, 1) != date(2022, 10, 1)
 
-        # error on attempt to compare when precision is not known to the day
-        with pytest.raises(
-            NotImplementedError,
-            match="Equality comparision with datetime.date not supported for YEAR precision",
-        ):
-            assert Undate(2022) == date(2022, 10, 1)
+        # other date precisions are not equal
+        assert Undate(2022) != date(2022, 10, 1)
+        assert Undate(2022, 10) != date(2022, 10, 1)
 
     def test_not_eq(self):
         assert Undate(2022) != Undate(2023)
@@ -169,6 +171,9 @@ class TestUndate:
         # partially known digits where comparison is possible
         (Undate("19XX"), Undate("20XX")),
         (Undate(1900, "0X"), Undate(1900, "1X")),
+        # compare with datetime.date objects
+        (Undate("19XX"), date(2020, 1, 1)),
+        (Undate(1991, 1), date(1992, 3, 4)),
     ]
 
     @pytest.mark.parametrize("earlier,later", testdata_lt_gt)
@@ -183,6 +188,8 @@ class TestUndate:
             (Undate(1601), Undate(1601)),
             (Undate(1991, 1), Undate(1991, 1)),
             (Undate(1492, 5, 3), Undate(1492, 5, 3)),
+            # compare with datetime.date also
+            (Undate(1492, 5, 3), date(1492, 5, 3)),
         ]
     )
 
@@ -190,6 +197,9 @@ class TestUndate:
         # strict less than / greater should return false when equal
         assert not Undate(1900) > Undate(1900)
         assert not Undate(1900) < Undate(1900)
+        # same for datetime.date
+        assert not Undate(1903, 1, 5) < date(1903, 1, 5)
+        assert not Undate(1903, 1, 5) > date(1903, 1, 5)
 
     @pytest.mark.parametrize("earlier,later", testdata_lte_gte)
     def test_lte(self, earlier, later):
@@ -214,6 +224,9 @@ class TestUndate:
         (Undate(2022, 1, 1), Undate(2022)),
         (Undate(2022, 12, 31), Undate(2022)),
         (Undate(2022, 6, 15), Undate(2022, 6)),
+        # support contains with datetime.date
+        (date(2022, 6, 1), Undate(2022)),
+        (date(2022, 6, 1), Undate(2022, 6)),
     ]
 
     @pytest.mark.parametrize("date1,date2", testdata_contains)
@@ -225,6 +238,9 @@ class TestUndate:
         (Undate(1980), Undate(2020)),
         (Undate(1980), Undate(2020, 6)),
         (Undate(1980, 6), Undate(2020, 6)),
+        # support contains with datetime.date
+        (date(1980, 6, 1), Undate(2022)),
+        (date(3001, 6, 1), Undate(2022, 6)),
         # partially known dates that are similar but same precision,
         # so one does not contain the other
         (Undate("199X"), Undate("19XX")),

--- a/tests/test_undate.py
+++ b/tests/test_undate.py
@@ -1,8 +1,13 @@
-from datetime import timedelta
+from datetime import timedelta, date
 
 import pytest
 
-from undate.undate import Undate, UndateInterval
+from undate.undate import Undate, UndateInterval, DatePrecision
+
+
+class TestDatePrecision:
+    def test_str(self):
+        assert str(DatePrecision.YEAR) == "YEAR"
 
 
 class TestUndate:
@@ -126,6 +131,19 @@ class TestUndate:
         assert Undate(2022, 10) == Undate(2022, 10)
         assert Undate(2022, 10, 1) == Undate(2022, 10, 1)
         assert Undate(month=2, day=7) == Undate(month=2, day=7)
+
+    def test_eq_datetime_date(self):
+        # support comparisons with datetime objects for full day-precision
+        assert Undate(2022, 10, 1) == date(2022, 10, 1)
+        assert Undate(2022, 10, 1) != date(2022, 10, 2)
+        assert Undate(2022, 10, 1) != date(2021, 10, 1)
+
+        # error on attempt to compare when precision is not known to the day
+        with pytest.raises(
+            NotImplementedError,
+            match="Equality comparision with datetime.date not supported for YEAR precision",
+        ):
+            assert Undate(2022) == date(2022, 10, 1)
 
     def test_not_eq(self):
         assert Undate(2022) != Undate(2023)


### PR DESCRIPTION
- improved equality check, including support for comparing `Undate` object with day precision to `datetime.date`
- implementations for `__lt__` , `__le__`, and `__contains__`
- tests for comparison, sorting and `in` (contains)
- static method to initialize an `Undate` object from a `datetime.date`, to simplify comparison logic

I'm sure there are cases I'm not handling or assumptions I'm making that don't always hold, so please point out any you can think of and then we can decide whether to fix as part of this PR or create separate issues for additional cases.
