### PR TITLE
Type cleanup based on errors reported by mypy

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,4 @@
-name: style + docs check
+name: style|docs|types
 
 on:
   pull_request:
@@ -12,9 +12,9 @@ jobs:
         working-directory: .
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: 'pip'
@@ -26,3 +26,8 @@ jobs:
         run: black src --check --diff
       - name: Check that documentation can be built
         run: tox -e docs
+      - name: Check python types with mypy
+        run: |
+          pip install mypy
+          mypy --install-types
+          mypy src/

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Check python types with mypy
         run: |
           pip install mypy
-          mypy --install-types
+          mypy --install-types --non-interactive
           mypy src/

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,4 @@
-name: style|docs|types
+name: Check style + docs + types
 
 on:
   pull_request:
@@ -22,12 +22,19 @@ jobs:
       - name: Install package with dependencies
         run: pip install -e ".[dev]"
         if: steps.python-cache.outputs.cache-hit != 'true'
+
+      # check code style
       - name: Run black
         run: black src --check --diff
+
+      # check docs
       - name: Check that documentation can be built
         run: tox -e docs
-      - name: Check python types with mypy
-        run: |
-          pip install mypy
-          mypy --install-types --non-interactive
-          mypy src/
+
+      # check types with mypy
+      - name: Install mypy
+        run: pip install mypy
+      - name: Install mypy types for current directory
+        run: mypy --install-types --non-interactive .
+      - name: Run mypy against src
+        run: mypy src/

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,7 +34,5 @@ jobs:
       # check types with mypy
       - name: Install mypy
         run: pip install mypy
-      - name: Install mypy types for current directory
-        run: mypy --install-types --non-interactive .
-      - name: Run mypy against src
-        run: mypy src/
+      - name: Check types in python src directory; install needed types
+        run: mypy --install-types --non-interactive src

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,14 +11,14 @@ on:
 
 env:
   # python version used to calculate and submit code coverage
-  COV_PYTHON_VERSION: "3.10"
+  COV_PYTHON_VERSION: "3.11"
 
 jobs:
   python-unit:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
     defaults:
       run:
         working-directory: .

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,10 +15,10 @@ keywords = "dates dating uncertainty uncertain-dates unknown partially-known dig
 classifiers =
     Development Status :: 2 - Pre-Alpha
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
@@ -63,7 +63,7 @@ test =
   pytest-ordering
   pytest-cov
 docs =
-  sphinx<7.0.0  
+  sphinx<7.0.0
   sphinx_rtd_theme
   m2r2
 # pin sphinx because 7.0 currently not compatible with rtd theme
@@ -72,15 +72,15 @@ docs =
 where = src
 
 [tox:tox]
-envlist = py38, py39, py310, py311
+envlist = py39, py310, py311, py312
 isolated_build = True
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [pytest]
 minversion = 6.0

--- a/src/undate/dateformat/base.py
+++ b/src/undate/dateformat/base.py
@@ -15,7 +15,7 @@ returned by :meth:`BaseDateFormat.available_formatters`
 import importlib
 import logging
 import pkgutil
-from typing import Dict
+from typing import Dict, Type
 from functools import lru_cache  # functools.cache not available until 3.9
 
 
@@ -66,7 +66,7 @@ class BaseDateFormat:
         return import_count
 
     @classmethod
-    def available_formatters(cls) -> Dict[str, "BaseDateFormat"]:
+    def available_formatters(cls) -> Dict[str, Type["BaseDateFormat"]]:
         # ensure undate formatters are imported
         cls.import_formatters()
         return {c.name: c for c in cls.__subclasses__()}  # type: ignore

--- a/src/undate/dateformat/base.py
+++ b/src/undate/dateformat/base.py
@@ -41,11 +41,12 @@ class BaseDateFormat:
     # cache import class method to ensure we only import once
     @classmethod
     @lru_cache
-    def import_formatters(cls):
+    def import_formatters(cls) -> int:
         """Import all undate.dateformat formatters
         so that they will be included in available formatters
         even if not explicitly imported. Only import once.
         returns the count of modules imported."""
+
         logger.debug("Loading formatters under undate.dateformat")
         import undate.dateformat
 

--- a/src/undate/dateformat/iso8601.py
+++ b/src/undate/dateformat/iso8601.py
@@ -28,7 +28,12 @@ class ISO8601DateFormat(BaseDateFormat):
         if len(parts) == 1:
             return self._parse_single_date(parts[0])
         elif len(parts) == 2:
-            return UndateInterval(*[self._parse_single_date(p) for p in parts])
+            # date range; parse both parts and initialize an interval
+            start, end = [self._parse_single_date(p) for p in parts]
+            return UndateInterval(start, end)
+        else:
+            # more than two parts = unexpected input
+            raise ValueError
 
     def _parse_single_date(self, value: str) -> Undate:
         # split single iso date into parts; convert to int or None

--- a/tests/test_dateformat/edtf/test_edtf_transformer.py
+++ b/tests/test_dateformat/edtf/test_edtf_transformer.py
@@ -41,4 +41,6 @@ def test_transform(date_string, expected):
     transformer = EDTFTransformer()
     # parse the input string, then transform to undate object
     parsetree = edtf_parser.parse(date_string)
-    assert transformer.transform(parsetree) == expected
+    # since the same unknown date is not considered strictly equal,
+    # compare object representations
+    assert repr(transformer.transform(parsetree)) == repr(expected)

--- a/tests/test_undate.py
+++ b/tests/test_undate.py
@@ -273,3 +273,6 @@ class TestUndateInterval:
             Undate(None, 6, 7), Undate(None, 6, 6)
         ).duration()
         assert month_noyear_duration.days == 365
+
+        # duration is not supported for open-ended intervals
+        assert UndateInterval(Undate(2000), None).duration() == NotImplemented


### PR DESCRIPTION
per #29 — trying out mypy and updating our type annotations based on the reported errors (not all resolved)

I'm installing and checking manually for now:
```sh
pip install mypy
mypy --install-types
mypy src/
```

here are the errors being reported now, after the changes made in this branch:
```
src/undate/undate.py:145: error: "BaseDateFormat" not callable  [operator]
src/undate/undate.py:146: error: Incompatible types in assignment (expression has type "Optional[BaseDateFormat]", variable has type "BaseDateFormat")  [assignment]
src/undate/undate.py:246: error: Syntax error in type annotation  [syntax]
src/undate/undate.py:246: note: Suggestion: Use Tuple[T1, ..., Tn] instead of (T1, ..., Tn)
Found 3 errors in 1 file (checked 5 source files)
```