### PR TITLE
Check notebooks in CI `check` workflow #76

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.10"
           cache: 'pip'
           cache-dependency-path: '**/setup.cfg'
-      - name: Install package with dependencies
+      - name: Install package with development dependencies
         run: pip install -e ".[dev]"
         if: steps.python-cache.outputs.cache-hit != 'true'
 
@@ -32,7 +32,9 @@ jobs:
         run: tox -e docs
 
       # check types with mypy
-      - name: Install mypy
-        run: pip install mypy
       - name: Check types in python src directory; install needed types
         run: mypy --install-types --non-interactive src
+
+      # use treon to make sure that example notebooks run
+      - name: Check jupyter notebooks with treon
+        run: treon

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ venv.bak/
 # code coverage
 .coverage
 coverage.xml
+
+# jupyter
+.ipynb_checkpoints/

--- a/examples/notebooks/shxco_partial_date_durations.ipynb
+++ b/examples/notebooks/shxco_partial_date_durations.ipynb
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -51,14 +51,6 @@
     "outputId": "ee3cacd7-c347-437a-ee8e-91a4086d6e88"
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/tn/1_gbhpks7hqbkbln2gjhcdvm0000gp/T/ipykernel_37223/1465467117.py:6: DtypeWarning: Columns (20) have mixed types. Specify dtype option on import or set low_memory=False.\n",
-      "  events_df = pd.read_csv(\"https://github.com/rlskoeser/shxco-missingdata-specreading/raw/main/data/source-data/SCoData_events_v1.2_2022-01.csv\")\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -296,7 +288,7 @@
        "[5 rows x 28 columns]"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -304,10 +296,8 @@
    "source": [
     "import pandas as pd\n",
     "\n",
-    "# load the 1.2 version of S&co events dataset\n",
-    "# for convenience, we load a copy from \n",
-    "\n",
-    "events_df = pd.read_csv(\"https://github.com/rlskoeser/shxco-missingdata-specreading/raw/main/data/source-data/SCoData_events_v1.2_2022-01.csv\")\n",
+    "# load the 1.2 version of S&co events dataset; we have a copy in our use-cases folder\n",
+    "events_df = pd.read_csv(\"../use-cases/shakespeare-and-company-project/SCoData_events_v1.2_2022-01.csv\", low_memory=False)\n",
     "events_df.head()"
    ]
   },

--- a/examples/use-cases/shakespeare-and-company-project/README.md
+++ b/examples/use-cases/shakespeare-and-company-project/README.md
@@ -1,0 +1,18 @@
+# Data from the Shakespeare and Company Project
+
+The [Shakespeare and Company Project](https://shakespeareandco.princeton.edu/) publishes an events dataset that document lending library activities such as subscribing, renewing, and borrowing and returning books. Some of the dates for those events are only partially known.
+
+Dates are in ISO8601 format in one of the following formats: YYYY, YYYY-MM, YYYY-MM-DD, --MM-DD.
+
+Event dates are used for sorting, for filtering to determine if a member was active in a particular year, and for determining durations - how long a subscription lasted for, or how long a borrowed book was out. One special case is borrow events with unknown years: the Project assumes that the return was the same or successive year, so even though the years are unknown the duration can be calculated.
+
+The dataset includes durations for subscriptions and borrow events in human readable format and number of days.
+
+----
+
+This dataset is included here as a convenient example. If you want use it elsewhere, please
+reference the record with additional information and cite it properly.
+
+https://doi.org/10.34770/nz90-ym25
+
+

--- a/examples/use-cases/shakespeare-and-company-project/README.md
+++ b/examples/use-cases/shakespeare-and-company-project/README.md
@@ -1,6 +1,6 @@
 # Data from the Shakespeare and Company Project
 
-The [Shakespeare and Company Project](https://shakespeareandco.princeton.edu/) publishes an events dataset that document lending library activities such as subscribing, renewing, and borrowing and returning books. Some of the dates for those events are only partially known.
+The [Shakespeare and Company Project](https://shakespeareandco.princeton.edu/) publishes an events dataset that documents lending library activities such as subscribing, renewing, and borrowing and returning books. Some of the dates for those events are only partially known.
 
 Dates are in ISO8601 format in one of the following formats: YYYY, YYYY-MM, YYYY-MM-DD, --MM-DD.
 
@@ -10,7 +10,7 @@ The dataset includes durations for subscriptions and borrow events in human read
 
 ----
 
-This dataset is included here as a convenient example. If you want use it elsewhere, please
+This dataset is included here as a convenient example. If you want to use it elsewhere, please
 reference the record with additional information and cite it properly.
 
 https://doi.org/10.34770/nz90-ym25

--- a/examples/use-cases/shakespeare-and-company-project/README.md
+++ b/examples/use-cases/shakespeare-and-company-project/README.md
@@ -1,5 +1,7 @@
 # Data from the Shakespeare and Company Project
 
+Rebecca Sutton Koeser, Center for Digital Humanities at Princeton
+
 The [Shakespeare and Company Project](https://shakespeareandco.princeton.edu/) publishes an events dataset that documents lending library activities such as subscribing, renewing, and borrowing and returning books. Some of the dates for those events are only partially known.
 
 Dates are in ISO8601 format in one of the following formats: YYYY, YYYY-MM, YYYY-MM-DD, --MM-DD.
@@ -8,10 +10,14 @@ Event dates are used for sorting, for filtering to determine if a member was act
 
 The dataset includes durations for subscriptions and borrow events in human readable format and number of days.
 
+The [Shakespeare and Company Project codebase](https://github.com/Princeton-CDH/mep-django) that generated these datasets includes code for working with "partial dates" (this work is a precursor to `undate`). When working with the web application and database, it's possible to perform calculations and filtering that makes use of whatever parts of the date are known. Because we anticipated this would be difficult or impossible without that custom code, the datasets include the dates in ISO8601 as well as certain calculations based on those dates, including years of library membership or book circulation and duration of borrowing events and subscriptions in both human readable and machine readable form (text and count by days). 
+
+Data analysis tasks that take these kinds of dates into account currently require either ignoring partially known dates or coercing them to a specific date, e.g. the first day of the month or year. (For an example of analytic time-based work on this data, see ["Missing Data, Speculative Reading"](https://doi.org/10.22148/001c.116926) by Koeser and LeBlanc, and [accompanying research code](https://github.com/rlskoeser/shxco-missingdata-specreading)). Our hope is that in the future, `undate` will make it possible to work with those partial dates instead of ignoring them.
+
 ----
 
-This dataset is included here as a convenient example. If you want to use it elsewhere, please
-reference the record with additional information and cite it properly.
+This dataset is included here as an example for convenience. If you want to use it elsewhere, please
+reference the record with additional information, cite it properly, and make sure you're using the most recent published version.
 
 https://doi.org/10.34770/nz90-ym25
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,8 @@ dev =
   wheel
   build
   mypy
+  treon
+  lxml_html_clean
   %(docs)s
 test =
   pytest>=7.2
@@ -67,7 +69,9 @@ docs =
   sphinx<7.0.0
   sphinx_rtd_theme
   m2r2
+# NOTES:
 # pin sphinx because 7.0 currently not compatible with rtd theme
+# treon fails without lxml_html_clean (now a separate/optional package from lxml)
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ dev =
   build
   mypy
   treon
-  lxml_html_clean
+  nbconvert>=7.1.0
   %(docs)s
 test =
   pytest>=7.2
@@ -71,7 +71,7 @@ docs =
   m2r2
 # NOTES:
 # pin sphinx because 7.0 currently not compatible with rtd theme
-# treon fails without lxml_html_clean (now a separate/optional package from lxml)
+# treon depends on nbconvert; require newer version to avoid lxml_html_clean dependency error
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
ref #76 

Add check for jupyter notebooks using [treon](https://github.com/ReviewNB/treon)

Update example notebook so it passes the check; use local data instead of remote.

Add Shakespeare and Company Project events dataset to use cases - both as an example and so we can reference it in the notebook.

## todo:
- [x] check if extra lxml dependency is still needed
- [x] summarize payoff / value of using undate for S&co dataset use case in the example readme
