### PR TITLE
Find all converter subclasses / descendants

### DIFF
--- a/src/undate/converters/base.py
+++ b/src/undate/converters/base.py
@@ -114,7 +114,7 @@ class BaseDateConverter:
         return {c.name: c for c in cls.subclasses()}  # type: ignore
 
     @classmethod
-    def subclasses(cls) -> list[Type["BaseDateConverter"]]:
+    def subclasses(cls) -> set[Type["BaseDateConverter"]]:
         """
         List of available converters classes. Includes calendar convert
         subclasses.
@@ -123,11 +123,16 @@ class BaseDateConverter:
         cls.import_converters()
 
         # find all direct subclasses, excluding base calendar converter
-        subclasses = cls.__subclasses__()
-        subclasses.remove(BaseCalendarConverter)
-        # add all subclasses of calendar converter base class
-        subclasses.extend(BaseCalendarConverter.__subclasses__())
-        return subclasses
+        direct_subclasses = cls.__subclasses__()
+        all_subclasses = set(direct_subclasses)
+        # recurse to find nested subclasses
+        for subc in direct_subclasses:
+            # print(f"class subclasses: {subc.name} {subc.subclasses()}")
+            all_subclasses |= subc.subclasses()
+
+        # omit the calendar converter base class, which is not itself a converter
+        all_subclasses -= {BaseCalendarConverter}
+        return all_subclasses
 
 
 class BaseCalendarConverter(BaseDateConverter):

--- a/src/undate/converters/base.py
+++ b/src/undate/converters/base.py
@@ -128,7 +128,6 @@ class BaseDateConverter:
         all_subclasses = set(direct_subclasses)
         # recurse to find nested subclasses
         for subc in direct_subclasses:
-            # print(f"class subclasses: {subc.name} {subc.subclasses()}")
             all_subclasses |= subc.subclasses()
 
         # omit the calendar converter base class, which is not itself a converter

--- a/src/undate/converters/base.py
+++ b/src/undate/converters/base.py
@@ -116,8 +116,9 @@ class BaseDateConverter:
     @classmethod
     def subclasses(cls) -> set[Type["BaseDateConverter"]]:
         """
-        List of available converters classes. Includes calendar convert
-        subclasses.
+        Set of available converters classes. Includes descendant
+        subclasses, including calendar converters, but does not include
+        :class:`BaseCalendarConverter`.
         """
         # ensure undate converters are imported
         cls.import_converters()

--- a/tests/test_converters/test_base.py
+++ b/tests/test_converters/test_base.py
@@ -2,6 +2,11 @@ import logging
 
 import pytest
 from undate.converters.base import BaseDateConverter, BaseCalendarConverter
+from undate.converters.calendars import (
+    GregorianDateConverter,
+    HebrewDateConverter,
+    HijriDateConverter,
+)
 
 
 class TestBaseDateConverter:
@@ -28,6 +33,18 @@ class TestBaseDateConverter:
     def test_parse_to_string(self):
         with pytest.raises(NotImplementedError):
             BaseDateConverter().to_string(1991)
+
+    def test_subclasses(self):
+        # define a nested subclass
+        class SubSubConverter(HijriDateConverter):
+            pass
+
+        subclasses = BaseDateConverter.subclasses()
+        assert BaseCalendarConverter not in subclasses
+        assert HijriDateConverter in subclasses
+        assert HebrewDateConverter in subclasses
+        assert GregorianDateConverter in subclasses
+        assert SubSubConverter in subclasses
 
 
 def test_import_converters_import_only_once(caplog):


### PR DESCRIPTION
Revises converter subclass logic to find nested / descendant classes. 

This resolves an issue I discovered when I tried to subclass the Hebrew converter to add a Seleucid calendar converter and the subclass wasn't being found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the mechanism for gathering converter classes by switching from a list to a set and enabling recursive inclusion of all nested converter types while excluding specific ones.
- **Tests**
	- Introduced a new test to verify that the updated converter collection correctly identifies subclasses, ensuring expected converters are included while excluding specific ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->