### PR TITLE
Document that duration calculation is inclusive / closed interval

### DIFF
--- a/src/undate/undate.py
+++ b/src/undate/undate.py
@@ -420,9 +420,9 @@ class Undate:
         """What is the duration of this date?
         Calculate based on earliest and latest date within range,
         taking into account the precision of the date even if not all
-        parts of the date are known. Note that durations are inclusive,
-        and include both the earliest and latest date rather than the
-        difference between them."""
+        parts of the date are known. Note that durations are inclusive
+        (i.e., a closed interval)  and include both the earliest and latest
+        date rather than the difference between them."""
 
         # if precision is a single day, duration is one day
         # no matter when it is or what else is known
@@ -543,8 +543,9 @@ class UndateInterval:
 
     def duration(self) -> Timedelta:
         """Calculate the duration between two undates.
-        Note that durations are inclusive, and include both the earliest and latest
-        date rather than the difference between them.
+        Note that durations are inclusive (i.e., a closed interval), and
+        include both the earliest and latest date rather than the difference
+        between them.
 
         :returns: A duration
         :rtype: Timedelta

--- a/src/undate/undate.py
+++ b/src/undate/undate.py
@@ -420,7 +420,9 @@ class Undate:
         """What is the duration of this date?
         Calculate based on earliest and latest date within range,
         taking into account the precision of the date even if not all
-        parts of the date are known."""
+        parts of the date are known. Note that durations are inclusive,
+        and include both the earliest and latest date rather than the
+        difference between them."""
 
         # if precision is a single day, duration is one day
         # no matter when it is or what else is known
@@ -541,6 +543,8 @@ class UndateInterval:
 
     def duration(self) -> Timedelta:
         """Calculate the duration between two undates.
+        Note that durations are inclusive, and include both the earliest and latest
+        date rather than the difference between them.
 
         :returns: A duration
         :rtype: Timedelta


### PR DESCRIPTION
This is to address #63 - I think the best approach is to document clearly how we calculate durations, and allow projects that need to revise the logic to handle it outside of undate code.  We could consider adding other variation logic later as a refinement (e.g. open and half-open intervals), but I think documenting the logic should be enough for now.