### PR TITLE
Preliminary rdflib resource for ISMI CIDOC-CRM time spans

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13"]
     defaults:
       run:
         working-directory: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = { text = "Apache-2" }
 requires-python = ">= 3.10"
 dynamic = ["version"]
-dependencies = ["lark[interegular]", "numpy", "convertdate", "strenum; python_version < '3.11'"]
+dependencies = ["lark[interegular]", "numpy", "convertdate", "strenum; python_version < '3.11'", "rdflib"]
 authors = [
     { name = "Rebecca Sutton Koeser" },
     { name = "Cole Crawford" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "undate"
 description = "library for working with uncertain, fuzzy, or partially unknown dates and date intervals"
 readme = "README.md"
 license = { text = "Apache-2" }
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 dynamic = ["version"]
 dependencies = ["lark[interegular]", "numpy", "convertdate", "strenum; python_version < '3.11'"]
 authors = [
@@ -31,7 +31,6 @@ keywords = [
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/src/undate/converters/cidoc_crm.py
+++ b/src/undate/converters/cidoc_crm.py
@@ -1,5 +1,6 @@
 import rdflib
 
+from undate import Undate
 
 #: CIDOC-CRM namespace
 CIDOC_CRM = rdflib.Namespace("http://www.cidoc-crm.org/cidoc-crm/")
@@ -14,18 +15,23 @@ ISMI_CALENDAR_TYPE = rdflib.Namespace(
 class TimeSpan(rdflib.resource.Resource):
     @property
     def identified_by(self):
+        # by default, rdflib resource value method will return another Resource
         return self.value(CIDOC_CRM.P1_is_identified_by)
 
     @property
     def label(self):
+        # for ISMI records, label is under the crm identifier/appelation
+        # other examples have it directly under the time span as RDFS.label
         return self.identified_by.value(rdflib.RDFS.label)
 
     @property
     def calendar(self):
+        # for ISMI records, calendar type is associated with identifier
         return self.identified_by.value(CIDOC_CRM.P2_has_type).identifier
 
     @property
     def type(self):
+        # CIDOC-CRM type
         return self.value(CIDOC_CRM.P2_has_type).identifier
 
     @property
@@ -45,24 +51,23 @@ class TimeSpan(rdflib.resource.Resource):
         return self.value(CIDOC_CRM.P3_has_note)
 
     def to_undate(self):
-        # day precision
-        if self.type == ISMI_DATE_TYPE.day:
-            return self.at_some_time_within.toPython()
+        # convert to an undate object, if possible
+        match self.type:
+            # day precision
+            case ISMI_DATE_TYPE.day:
+                # at_some_time_within is xsd:date; use toPython method
+                # to convert to datetime.date and then convert to undate
+                return Undate.to_undate(self.at_some_time_within.toPython())
+                # TODO: should we set label before returning?
+
+                # for ISMI dates, could we parse the label and preserve calendar information?
 
     @classmethod
     def time_spans_from_graph(cls, graph):
-        """Class method to find and return all CIDOC-CRM timespans in an rdflib graph
-        and yield them as :class:`TimeSpan` resource objects."""
+        """Find and return all entities with CIDOC-CRM type E52 Time-Span
+        within the rdflib graph and yield them as :class:`TimeSpan`
+        resources."""
         for timespan_uri in graph.subjects(
             predicate=rdflib.RDF.type, object=CIDOC_CRM["E52_Time-Span"]
         ):
             yield cls(graph, timespan_uri)
-
-
-#  # crm:P2_has_type datetype:day ;
-#   crm:P82_at_some_time_within "1495-12-11"^^xsd:date ;
-#   crm:P3_has_note "day-precision date in islamic calendar" ;
-#   crm:P1_is_identified_by :date1-label .
-# :date1-label a crm:E41_Appellation ;
-#   crm:P2_has_type calendartype:islamic ;
-#   rdfs:label "901 Rabīʿ I 14 (islamic)" .

--- a/src/undate/converters/cidoc_crm.py
+++ b/src/undate/converters/cidoc_crm.py
@@ -1,0 +1,68 @@
+import rdflib
+
+
+#: CIDOC-CRM namespace
+CIDOC_CRM = rdflib.Namespace("http://www.cidoc-crm.org/cidoc-crm/")
+ISMI_DATE_TYPE = rdflib.Namespace(
+    "http://content.mpiwg-berlin.mpg.de/ns/ismi/type/date/"
+)
+ISMI_CALENDAR_TYPE = rdflib.Namespace(
+    "http://content.mpiwg-berlin.mpg.de/ns/ismi/type/calendar/"
+)
+
+
+class TimeSpan(rdflib.resource.Resource):
+    @property
+    def identified_by(self):
+        return self.value(CIDOC_CRM.P1_is_identified_by)
+
+    @property
+    def label(self):
+        return self.identified_by.value(rdflib.RDFS.label)
+
+    @property
+    def calendar(self):
+        return self.identified_by.value(CIDOC_CRM.P2_has_type).identifier
+
+    @property
+    def type(self):
+        return self.value(CIDOC_CRM.P2_has_type).identifier
+
+    @property
+    def at_some_time_within(self):
+        return self.value(CIDOC_CRM.P82_at_some_time_within)
+
+    @property
+    def begin_of_the_begin(self):
+        return self.value(CIDOC_CRM.P82a_begin_of_the_begin)
+
+    @property
+    def end_of_the_end(self):
+        return self.value(CIDOC_CRM.P82b_end_of_the_end)
+
+    @property
+    def note(self):
+        return self.value(CIDOC_CRM.P3_has_note)
+
+    def to_undate(self):
+        # day precision
+        if self.type == ISMI_DATE_TYPE.day:
+            return self.at_some_time_within.toPython()
+
+    @classmethod
+    def time_spans_from_graph(cls, graph):
+        """Class method to find and return all CIDOC-CRM timespans in an rdflib graph
+        and yield them as :class:`TimeSpan` resource objects."""
+        for timespan_uri in graph.subjects(
+            predicate=rdflib.RDF.type, object=CIDOC_CRM["E52_Time-Span"]
+        ):
+            yield cls(graph, timespan_uri)
+
+
+#  # crm:P2_has_type datetype:day ;
+#   crm:P82_at_some_time_within "1495-12-11"^^xsd:date ;
+#   crm:P3_has_note "day-precision date in islamic calendar" ;
+#   crm:P1_is_identified_by :date1-label .
+# :date1-label a crm:E41_Appellation ;
+#   crm:P2_has_type calendartype:islamic ;
+#   rdfs:label "901 Rabīʿ I 14 (islamic)" .

--- a/src/undate/interval.py
+++ b/src/undate/interval.py
@@ -73,6 +73,9 @@ class UndateInterval:
         return "<UndateInterval %s>" % self
 
     def __eq__(self, other) -> bool:
+        # currently doesn't support comparison with any other types
+        if not isinstance(other, UndateInterval):
+            return NotImplemented
         # consider interval equal if both dates are equal
         return self.earliest == other.earliest and self.latest == other.latest
 

--- a/src/undate/interval.py
+++ b/src/undate/interval.py
@@ -122,3 +122,27 @@ class UndateInterval:
             # is there any meaningful way to calculate duration
             # if one year is known and the other is not?
             raise NotImplementedError
+
+    def intersection(self, other: "UndateInterval") -> Optional["UndateInterval"]:
+        """Determine the intersection or overlap between two :class:`UndateInterval`
+        objects and return a new interval, or None if no overlap.
+        """
+        try:
+            # when both values are defined, return the inner bounds;
+            # if not, return whichever is not None, or None
+            earliest = (
+                max(self.earliest, other.earliest)
+                if self.earliest and other.earliest
+                else self.earliest or other.earliest
+            )
+            latest = (
+                min(self.latest, other.latest)
+                if self.latest and other.latest
+                else self.latest or other.latest
+            )
+
+            # if this results in an invalid interval, initialization
+            # will throw an exception
+            return UndateInterval(earliest, latest)
+        except ValueError:
+            return None

--- a/src/undate/interval.py
+++ b/src/undate/interval.py
@@ -36,15 +36,17 @@ class UndateInterval:
         if earliest:
             try:
                 earliest = Undate.to_undate(earliest)
-            except TypeError:
+            except TypeError as err:
                 raise ValueError(
                     f"earliest date {earliest} cannot be converted to Undate"
-                )
+                ) from err
         if latest:
             try:
                 latest = Undate.to_undate(latest)
-            except TypeError:
-                raise ValueError(f"latest date {latest} cannot be converted to Undate")
+            except TypeError as err:
+                raise ValueError(
+                    f"latest date {latest} cannot be converted to Undate"
+                ) from err
 
         # check that the interval is valid
         if latest and earliest and latest <= earliest:
@@ -123,7 +125,7 @@ class UndateInterval:
 
     def intersection(self, other: "UndateInterval") -> Optional["UndateInterval"]:
         """Determine the intersection or overlap between two :class:`UndateInterval`
-        objects and return a new interval, or None if no overlap.
+        objects and return a new interval. Returns None if there is no overlap.
         """
         try:
             # when both values are defined, return the inner bounds;

--- a/src/undate/interval.py
+++ b/src/undate/interval.py
@@ -1,5 +1,3 @@
-import datetime
-
 # Pre 3.10 requires Union for multiple types, e.g. Union[int, None] instead of int | None
 from typing import Optional, Union
 
@@ -34,21 +32,18 @@ class UndateInterval:
         latest: Optional[Undate] = None,
         label: Optional[str] = None,
     ):
-        # for now, assume takes two undate objects;
-        # support conversion from datetime
-        if earliest and not isinstance(earliest, Undate):
-            # NOTE: some overlap with Undate._comparison_type method
-            # maybe support conversion from other formats later
-            if isinstance(earliest, datetime.date):
-                earliest = Undate.from_datetime_date(earliest)
-            else:
+        # takes two undate objects; allows conversion from supported types
+        if earliest:
+            try:
+                earliest = Undate.to_undate(earliest)
+            except TypeError:
                 raise ValueError(
                     f"earliest date {earliest} cannot be converted to Undate"
                 )
-        if latest and not isinstance(latest, Undate):
-            if isinstance(latest, datetime.date):
-                latest = Undate.from_datetime_date(latest)
-            else:
+        if latest:
+            try:
+                latest = Undate.to_undate(latest)
+            except TypeError:
                 raise ValueError(f"latest date {latest} cannot be converted to Undate")
 
         # check that the interval is valid

--- a/src/undate/undate.py
+++ b/src/undate/undate.py
@@ -72,6 +72,10 @@ class Undate:
         label: Optional[str] = None,
         calendar: Optional[Union[str, Calendar]] = None,
     ):
+        # everything is optional but something is required
+        if all([val is None for val in [year, month, day]]):
+            raise ValueError("At least one of year, month, or day must be specified")
+
         # keep track of initial values and which values are known
         # TODO: add validation: if str, must be expected length
         self.initial_values: Dict[str, Optional[Union[int, str]]] = {

--- a/tests/test_converters/test_cidoc_crm.py
+++ b/tests/test_converters/test_cidoc_crm.py
@@ -1,0 +1,62 @@
+import types
+
+import rdflib
+
+from undate.converters import cidoc_crm
+
+
+# TODO: maybe copy full example ismi data as fixture
+# so we have examples of all types to test against
+
+sample_data = """
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix crm: <http://www.cidoc-crm.org/cidoc-crm/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+# prefix for date and calendar type URIs
+@prefix datetype: <http://content.mpiwg-berlin.mpg.de/ns/ismi/type/date/> .
+@prefix calendartype: <http://content.mpiwg-berlin.mpg.de/ns/ismi/type/calendar/> .
+# prefix for sample data
+@prefix : <http://content.mpiwg-berlin.mpg.de/ns/ismi/> .
+
+# day-precision date in islamic calendar
+:date1 a crm:E52_Time-Span ;
+  crm:P2_has_type datetype:day ;
+  crm:P82_at_some_time_within "1495-12-11"^^xsd:date ;
+  crm:P3_has_note "day-precision date in islamic calendar" ;
+  crm:P1_is_identified_by :date1-label .
+:date1-label a crm:E41_Appellation ;
+  crm:P2_has_type calendartype:islamic ;
+  rdfs:label "901 Rabīʿ I 14 (islamic)" .
+"""
+
+ISMI_NS = rdflib.Namespace("http://content.mpiwg-berlin.mpg.de/ns/ismi/")
+DATE1_URI = rdflib.URIRef("http://content.mpiwg-berlin.mpg.de/ns/ismi/date1")
+
+
+class TestTimeSpan:
+    def test_properties(self):
+        # initialize a time span rdflib.resource for date1 in the sample data
+        g = rdflib.Graph()
+        g.parse(data=sample_data)
+
+        time_span = cidoc_crm.TimeSpan(g, DATE1_URI)
+        assert time_span.type == cidoc_crm.ISMI_DATE_TYPE.day
+        assert time_span.label == rdflib.term.Literal("901 Rabīʿ I 14 (islamic)")
+        assert time_span.calendar == cidoc_crm.ISMI_CALENDAR_TYPE.islamic
+        assert time_span.at_some_time_within == rdflib.term.Literal(
+            "1495-12-11", datatype=rdflib.XSD.date
+        )
+        assert time_span.note == rdflib.term.Literal(
+            "day-precision date in islamic calendar"
+        )
+
+    def test_time_spans_from_graph(self):
+        g = rdflib.Graph()
+        g.parse(data=sample_data)
+
+        time_spans = cidoc_crm.TimeSpan.time_spans_from_graph(g)
+        assert isinstance(time_spans, types.GeneratorType)
+        time_spans = list(time_spans)
+        assert len(time_spans) == 1
+        assert isinstance(time_spans[0], cidoc_crm.TimeSpan)
+        assert time_spans[0].identifier == DATE1_URI

--- a/tests/test_converters/test_cidoc_crm.py
+++ b/tests/test_converters/test_cidoc_crm.py
@@ -1,47 +1,45 @@
+import pathlib
 import types
 
+import pytest
 import rdflib
 
 from undate import Undate, DatePrecision
 from undate.converters import cidoc_crm
 
 
-# TODO: maybe copy full example ismi data as fixture
-# so we have examples of all types to test against
+# TODO: move or copy example ismi data to test for use as a fixture
+ISMI_DATA_PATH = (
+    pathlib.Path(__file__)
+    / ".."
+    / ".."
+    / ".."
+    / "examples"
+    / "use-cases"
+    / "ismi"
+    / "data"
+    / "ismi-crm-date-samples.ttl"
+)
 
-sample_data = """
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix crm: <http://www.cidoc-crm.org/cidoc-crm/> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-# prefix for date and calendar type URIs
-@prefix datetype: <http://content.mpiwg-berlin.mpg.de/ns/ismi/type/date/> .
-@prefix calendartype: <http://content.mpiwg-berlin.mpg.de/ns/ismi/type/calendar/> .
-# prefix for sample data
-@prefix : <http://content.mpiwg-berlin.mpg.de/ns/ismi/> .
-
-# day-precision date in islamic calendar
-:date1 a crm:E52_Time-Span ;
-  crm:P2_has_type datetype:day ;
-  crm:P82_at_some_time_within "1495-12-11"^^xsd:date ;
-  crm:P3_has_note "day-precision date in islamic calendar" ;
-  crm:P1_is_identified_by :date1-label .
-:date1-label a crm:E41_Appellation ;
-  crm:P2_has_type calendartype:islamic ;
-  rdfs:label "901 Rabīʿ I 14 (islamic)" .
-"""
-
-ISMI_NS = rdflib.Namespace("http://content.mpiwg-berlin.mpg.de/ns/ismi/")
 DATE1_URI = rdflib.URIRef("http://content.mpiwg-berlin.mpg.de/ns/ismi/date1")
 
 
+@pytest.fixture
+def ismi_data():
+    g = rdflib.Graph()
+    g.parse(ISMI_DATA_PATH)
+    return g
+
+
 class TestTimeSpan:
-    def test_properties(self):
+    def test_properties(self, ismi_data):
         # initialize a time span rdflib.resource for date1 in the sample data
         # TODO: convert to a fixture
-        g = rdflib.Graph()
-        g.parse(data=sample_data)
+        # g = rdflib.Graph()
+        # g.parse(ISMI_DATA_PATH)
+        # g.parse(data=sample_data)
 
-        time_span = cidoc_crm.TimeSpan(g, DATE1_URI)
+        time_span = cidoc_crm.TimeSpan(ismi_data, DATE1_URI)
         assert time_span.type == cidoc_crm.ISMI_DATE_TYPE.day
         assert time_span.label == rdflib.term.Literal("901 Rabīʿ I 14 (islamic)")
         assert time_span.calendar == cidoc_crm.ISMI_CALENDAR_TYPE.islamic
@@ -52,22 +50,17 @@ class TestTimeSpan:
             "day-precision date in islamic calendar"
         )
 
-    def test_time_spans_from_graph(self):
-        g = rdflib.Graph()
-        g.parse(data=sample_data)
-
-        time_spans = cidoc_crm.TimeSpan.time_spans_from_graph(g)
+    def test_time_spans_from_graph(self, ismi_data):
+        time_spans = cidoc_crm.TimeSpan.time_spans_from_graph(ismi_data)
         assert isinstance(time_spans, types.GeneratorType)
         time_spans = list(time_spans)
-        assert len(time_spans) == 1
+        # fixture has 9 time spans
+        assert len(time_spans) == 9
         assert isinstance(time_spans[0], cidoc_crm.TimeSpan)
         assert time_spans[0].identifier == DATE1_URI
 
-    def test_to_undate(self):
-        g = rdflib.Graph()
-        g.parse(data=sample_data)
-
-        time_span = cidoc_crm.TimeSpan(g, DATE1_URI)
+    def test_to_undate(self, ismi_data):
+        time_span = cidoc_crm.TimeSpan(ismi_data, DATE1_URI)
         ts_undate = time_span.to_undate()
         assert isinstance(ts_undate, Undate)
         # 1495-12-11"^^xsd:date ;

--- a/tests/test_converters/test_cidoc_crm.py
+++ b/tests/test_converters/test_cidoc_crm.py
@@ -2,6 +2,7 @@ import types
 
 import rdflib
 
+from undate import Undate, DatePrecision
 from undate.converters import cidoc_crm
 
 
@@ -36,6 +37,7 @@ DATE1_URI = rdflib.URIRef("http://content.mpiwg-berlin.mpg.de/ns/ismi/date1")
 class TestTimeSpan:
     def test_properties(self):
         # initialize a time span rdflib.resource for date1 in the sample data
+        # TODO: convert to a fixture
         g = rdflib.Graph()
         g.parse(data=sample_data)
 
@@ -60,3 +62,19 @@ class TestTimeSpan:
         assert len(time_spans) == 1
         assert isinstance(time_spans[0], cidoc_crm.TimeSpan)
         assert time_spans[0].identifier == DATE1_URI
+
+    def test_to_undate(self):
+        g = rdflib.Graph()
+        g.parse(data=sample_data)
+
+        time_span = cidoc_crm.TimeSpan(g, DATE1_URI)
+        ts_undate = time_span.to_undate()
+        assert isinstance(ts_undate, Undate)
+        # 1495-12-11"^^xsd:date ;
+        assert ts_undate.year == "1495"
+        assert ts_undate.month == "12"
+        assert ts_undate.day == "11"
+        assert ts_undate.precision == DatePrecision.DAY
+
+        # if we round trip the date it comes out the same
+        assert ts_undate.format("ISO8601") == str(time_span.at_some_time_within)

--- a/tests/test_converters/test_edtf.py
+++ b/tests/test_converters/test_edtf.py
@@ -64,8 +64,8 @@ class TestEDTFDateConverter:
 
         # if converter can't generate a string for the date,
         # it should return a value error
-        empty_undate = Undate()
-        empty_undate.precision = DatePrecision.DECADE
-        with pytest.raises(ValueError):
-            EDTFDateConverter().to_string(empty_undate)
+        # empty_undate = Undate()   # undate with no date information no longer supported
+        # empty_undate.precision = DatePrecision.DECADE
+        # with pytest.raises(ValueError):
+        #     EDTFDateConverter().to_string(empty_undate)
         # TODO: override missing digit and confirm replacement

--- a/tests/test_converters/test_edtf.py
+++ b/tests/test_converters/test_edtf.py
@@ -1,6 +1,5 @@
 import pytest
 from undate.converters.edtf import EDTFDateConverter
-from undate.date import DatePrecision
 from undate import Undate, UndateInterval
 
 

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -181,3 +181,51 @@ class TestUndateInterval:
         assert before_20th.intersection(after_c11th) == UndateInterval(
             Undate(1001), Undate(1901)
         )
+
+    def test_contains(self):
+        century11th = UndateInterval(Undate(1001), Undate(1100))
+        century20th = UndateInterval(Undate(1901), Undate(2000))
+        decade1990s = UndateInterval(Undate(1990), Undate(1999))
+        # an interval doesn't contain itself
+        for interval in [century11th, century20th, decade1990s]:
+            assert interval not in interval
+
+        # checking if an interval is within another interval
+        assert decade1990s in century20th
+        assert decade1990s not in century11th
+        assert century11th not in decade1990s
+        assert century20th not in decade1990s
+        # a specific date can be contained by an interval
+        y2k = Undate(2000)
+        assert y2k in century20th
+        assert y2k not in century11th
+        # partially known date should work too
+        april_someyear = Undate("198X", 4)
+        assert april_someyear in century20th
+        assert april_someyear not in century11th
+        # conversion from datetime.date also works
+        assert datetime.date(1922, 5, 1) in century20th
+        # unsupported types result in a type error
+        with pytest.raises(TypeError):
+            "nineteen-eighty-four" in century20th
+
+        # contains check with half-open intervals
+        after_c11th = UndateInterval(Undate(1001), None)
+        before_20th = UndateInterval(None, Undate(1901))
+        # neither of them contains the other
+        assert after_c11th not in before_20th
+        assert before_20th not in after_c11th
+        # nor are they contained by a smaller range
+        assert after_c11th not in decade1990s
+        assert before_20th not in decade1990s
+
+        # all of our previous test dates are in the 1900s,
+        # so they are after the 11th century and not before the 20th
+        for period in [decade1990s, y2k, april_someyear]:
+            assert period in after_c11th
+            assert period not in before_20th
+
+        # fully open interval - is this even meaningful?
+        whenever = UndateInterval(None, None)
+        assert decade1990s in whenever
+        assert whenever not in whenever

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -143,3 +143,35 @@ class TestUndateInterval:
         # one year set and the other not currently raises not implemented error
         with pytest.raises(NotImplementedError):
             UndateInterval(Undate(2000), Undate(month=10)).duration()
+
+    def test_intersection(self):
+        century11th = UndateInterval(Undate(1001), Undate(1100))
+        century20th = UndateInterval(Undate(1901), Undate(2000))
+        # no intersection
+        assert century11th.intersection(century20th) is None
+        # should work in either direction
+        assert century20th.intersection(century11th) is None
+
+        decade1990s = UndateInterval(Undate(1990), Undate(1999))
+        # intersection of an interval completely contained in another
+        # returns an interval equivalent to the smaller one
+        assert century20th.intersection(decade1990s) == decade1990s
+        assert decade1990s.intersection(century20th) == decade1990s
+
+        # partial overlap
+        nineties_oughts = UndateInterval(Undate(1990), Undate(2009))
+        assert century20th.intersection(nineties_oughts) == UndateInterval(
+            Undate(1990), Undate(2000)
+        )
+
+        # intersections between half open intervals
+        after_c11th = UndateInterval(Undate(1001), None)
+        assert after_c11th.intersection(century20th) == century20th
+        assert after_c11th.intersection(decade1990s) == decade1990s
+
+        before_20th = UndateInterval(None, Undate(1901))
+        assert before_20th.intersection(decade1990s) is None
+        assert before_20th.intersection(century11th) == century11th
+        assert before_20th.intersection(after_c11th) == UndateInterval(
+            Undate(1001), Undate(1901)
+        )

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -85,7 +85,7 @@ class TestUndateInterval:
     def test_eq_type_check(self):
         # doesn't currently support comparison with anything else
         interval = UndateInterval(Undate(900))
-        # returns NotIplemented if comparison with this type is not supported
+        # returns NotImplemented if comparison with this type is not supported
         assert interval.__eq__("foo") == NotImplemented
 
     def test_not_eq(self):
@@ -207,7 +207,7 @@ class TestUndateInterval:
         assert datetime.date(1922, 5, 1) in century20th
         # unsupported types result in a type error
         with pytest.raises(TypeError):
-            "nineteen-eighty-four" in century20th
+            assert "nineteen-eighty-four" in century20th
 
         # contains check with half-open intervals
         after_c11th = UndateInterval(Undate(1001), None)

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -82,6 +82,12 @@ class TestUndateInterval:
         )
         assert UndateInterval(Undate(2022, 5)) == UndateInterval(Undate(2022, 5))
 
+    def test_eq_type_check(self):
+        # doesn't currently support comparison with anything else
+        interval = UndateInterval(Undate(900))
+        # returns NotIplemented if comparison with this type is not supported
+        assert interval.__eq__("foo") == NotImplemented
+
     def test_not_eq(self):
         assert UndateInterval(Undate(2022), Undate(2023)) != UndateInterval(
             Undate(2022), Undate(2024)

--- a/tests/test_undate.py
+++ b/tests/test_undate.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 
 import pytest
 
@@ -142,10 +142,15 @@ class TestUndate:
         with pytest.raises(ValueError):
             Undate(1990, 22)
 
-    def test_from_datetime_date(self):
-        undate_from_date = Undate.from_datetime_date(date(2001, 3, 5))
+    def test_to_undate(self):
+        undate_from_date = Undate.to_undate(date(2001, 3, 5))
         assert isinstance(undate_from_date, Undate)
         assert undate_from_date == Undate(2001, 3, 5)
+
+        now = datetime.now()
+        undate_from_dt = Undate.to_undate(now)
+        assert isinstance(undate_from_dt, Undate)
+        assert undate_from_dt == Undate(now.year, now.month, now.day)
 
     # test properties for accessing parts of date
     def test_year_property(self):

--- a/tests/test_undate.py
+++ b/tests/test_undate.py
@@ -132,7 +132,10 @@ class TestUndate:
 
     def test_init_invalid(self):
         with pytest.raises(ValueError):
-            Undate("19xx")
+            Undate("19??")
+
+        with pytest.raises(ValueError, match="At least one of year, month, or day"):
+            Undate()
 
     def test_invalid_date(self):
         # invalid month should raise an error
@@ -156,10 +159,11 @@ class TestUndate:
         # unset year
         assert Undate(month=12, day=31).year == "XXXX"
 
+        # NOTE: no longer supported to inistalize undate with no date information
         # force method to hit conditional for date precision
-        some_century = Undate()
-        some_century.precision = DatePrecision.CENTURY
-        assert some_century.year is None
+        # some_century = Undate()
+        # some_century.precision = DatePrecision.CENTURY
+        # assert some_century.year is None
 
     def test_month_property(self):
         # one, two digit month

--- a/tests/test_undate.py
+++ b/tests/test_undate.py
@@ -152,6 +152,10 @@ class TestUndate:
         assert isinstance(undate_from_dt, Undate)
         assert undate_from_dt == Undate(now.year, now.month, now.day)
 
+        # unsupported type
+        with pytest.raises(TypeError):
+            Undate.to_undate("foo")
+
     # test properties for accessing parts of date
     def test_year_property(self):
         # two, three, four five digit years; numeric and string


### PR DESCRIPTION
@robcast I have preliminary work on an rdf resource class to map to your ISMI dates.  I called it `cidoc_ crm` but wonder if it should be made more explicit since it is particular to your implementation. (Hopefully in future we could generalize and make it more reusable)

I put it under converters but I'm not sure it can work the same as the other converters, since I think parsing and serializing both require the context of an rdf graph.  I have only implemented and tested one case for the `to_undate` method - I know you started on this in a notebook in another branch.  I think ideally it should use the calendar-aware date parsing and then use the other fields to check/validate the conversion, but that probably requires merging in one of my other branches first... 😅 

LMK what you think about the approach, names, conversion, etc.