### PR TITLE
Use `islamic` for Islamic/Hijri calendar classes  #120

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Currently available converters are "ISO8601" and "EDTF" and supported calendars.
 
 ### Calendars
 
-All `Undate` objects are calendar aware, and date converters include support for parsing and working with dates from other calendars. The Gregorian calendar is used by default; currently `undate` supports the Hijri Islamic calendar and the Anno Mundi Hebrew calendar based on calendar convertion logic implemented in the [convertdate](https://convertdate.readthedocs.io/en/latest/)package. 
+All `Undate` objects are calendar aware, and date converters include support for parsing and working with dates from other calendars. The Gregorian calendar is used by default; currently `undate` supports the Islamic Hijri calendar and the Hebrew Anno Mundi calendar based on calendar conversion logic implemented in the [convertdate](https://convertdate.readthedocs.io/en/latest/)package. 
 
 Dates are stored with the year, month, day and appropriate precision for the original calendar; internally, earliest and latest dates are calculated in Gregorian / Proleptic Gregorian calendar for standardized comparison across dates from different calendars.
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Currently available converters are "ISO8601" and "EDTF" and supported calendars.
 
 ### Calendars
 
-All `Undate` objects are calendar aware, and date converters include support for parsing and working with dates from other calendars. The Gregorian calendar is used by default; currently `undate` supports the Islamic Hijri calendar and the Hebrew Anno Mundi calendar based on calendar conversion logic implemented in the [convertdate](https://convertdate.readthedocs.io/en/latest/)package. 
+All `Undate` objects are calendar aware, and date converters include support for parsing and working with dates from other calendars. The Gregorian calendar is used by default; currently `undate` supports the Islamic Hijri calendar and the Hebrew Anno Mundi calendar based on calendar conversion logic implemented in the [convertdate](https://convertdate.readthedocs.io/en/latest/) package. 
 
 Dates are stored with the year, month, day and appropriate precision for the original calendar; internally, earliest and latest dates are calculated in Gregorian / Proleptic Gregorian calendar for standardized comparison across dates from different calendars.
 

--- a/docs/undate/converters.rst
+++ b/docs/undate/converters.rst
@@ -39,15 +39,15 @@ Gregorian
 .. automodule:: undate.converters.calendars.gregorian
    :members:
 
-Hijri (Islamic calendar)
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. automodule:: undate.converters.calendars.hijri.converter
-   :members:
-
-Anno Mundi (Hebrew calendar)
+Hebrew Anno Mundi calendar
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: undate.converters.calendars.hebrew.converter
+   :members:
+
+Islamic Hijri calendar
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: undate.converters.calendars.islamic.converter
    :members:
 

--- a/src/undate/converters/base.py
+++ b/src/undate/converters/base.py
@@ -3,7 +3,7 @@
 implementing date converters, which can provide support for
 parsing and generating dates in different formats.
 The converter subclass :class:`undate.converters.BaseCalendarConverter`
-provides additional functionaly needed for calendar conversion.
+provides additional functionality needed for calendar conversion.
 
 To add support for a new date converter:
 
@@ -23,10 +23,10 @@ To add support for a new calendar converter:
 
 - Create a new file under ``undate/converters/calendars/``
     - For converters with sufficient complexity, you may want to create a submodule;
-      see ``undate.converters.calendars.hijri`` for an example.
+      see ``undate.converters.calendars.islamic`` for an example.
 - Extend ``BaseCalendarConverter`` and implement ``parse`` and ``to_string``
   formatter methods as desired/appropriate for your converter as well as the
-  additional methods for ``max_month``, ``max_day``, and convertion ``to_gregorian``
+  additional methods for ``max_month``, ``max_day``, and conversion ``to_gregorian``
   calendar.
 - Import your calendar in ``undate/converters/calendars/__init__.py`` and include in `__all__``
 - Add unit tests for the new calendar logic under ``tests/test_converters/calendars/``

--- a/src/undate/converters/calendars/__init__.py
+++ b/src/undate/converters/calendars/__init__.py
@@ -1,5 +1,5 @@
 from undate.converters.calendars.gregorian import GregorianDateConverter
-from undate.converters.calendars.hijri import HijriDateConverter
 from undate.converters.calendars.hebrew import HebrewDateConverter
+from undate.converters.calendars.islamic import IslamicDateConverter
 
-__all__ = ["HijriDateConverter", "GregorianDateConverter", "HebrewDateConverter"]
+__all__ = ["GregorianDateConverter", "HebrewDateConverter", "IslamicDateConverter"]

--- a/src/undate/converters/calendars/hijri/__init__.py
+++ b/src/undate/converters/calendars/hijri/__init__.py
@@ -1,3 +1,0 @@
-from undate.converters.calendars.hijri.converter import HijriDateConverter
-
-__all__ = ["HijriDateConverter"]

--- a/src/undate/converters/calendars/hijri/parser.py
+++ b/src/undate/converters/calendars/hijri/parser.py
@@ -1,9 +1,0 @@
-import pathlib
-
-from lark import Lark
-
-grammar_path = pathlib.Path(__file__).parent / "hijri.lark"
-
-with open(grammar_path) as grammar:
-    # NOTE: LALR parser is faster but can't be used to ambiguity between years and dates
-    hijri_parser = Lark(grammar.read(), start="hijri_date", strict=True)

--- a/src/undate/converters/calendars/islamic/__init__.py
+++ b/src/undate/converters/calendars/islamic/__init__.py
@@ -1,0 +1,3 @@
+from undate.converters.calendars.islamic.converter import IslamicDateConverter
+
+__all__ = ["IslamicDateConverter"]

--- a/src/undate/converters/calendars/islamic/converter.py
+++ b/src/undate/converters/calendars/islamic/converter.py
@@ -5,24 +5,24 @@ from lark.exceptions import UnexpectedCharacters
 
 from undate import Undate, UndateInterval
 from undate.converters.base import BaseCalendarConverter
-from undate.converters.calendars.hijri.parser import hijri_parser
-from undate.converters.calendars.hijri.transformer import HijriDateTransformer
+from undate.converters.calendars.islamic.parser import islamic_parser
+from undate.converters.calendars.islamic.transformer import IslamicDateTransformer
 
 
-class HijriDateConverter(BaseCalendarConverter):
+class IslamicDateConverter(BaseCalendarConverter):
     """
-    Converter for Hijri / Islamic calendar.
+    Converter for Islamic Hijri calendar.
 
-    Support for parsing Hijri dates and converting to Undate and UndateInterval
+    Support for parsing Islamic Hijri dates and converting to Undate and UndateInterval
     objects in the Gregorian calendar.
     """
 
-    #: converter name: Hijri
-    name: str = "Hijri"
-    calendar_name: str = "Hijrī"
+    #: converter name: Islamic
+    name: str = "Islamic"
+    calendar_name: str = "Islamic"
 
     def __init__(self):
-        self.transformer = HijriDateTransformer()
+        self.transformer = IslamicDateTransformer()
 
     def max_day(self, year: int, month: int) -> int:
         """maximum numeric day for the specified year and month in this calendar"""
@@ -44,9 +44,9 @@ class HijriDateConverter(BaseCalendarConverter):
 
     def parse(self, value: str) -> Union[Undate, UndateInterval]:
         """
-        Parse a Hijri date string and return an :class:`~undate.undate.Undate` or
+        Parse an Islamic/Hijri date string and return an :class:`~undate.undate.Undate` or
         :class:`~undate.undate.UndateInterval`.
-        The Hijri date string is preserved in the undate label.
+        The Islamic/Hijri date string is preserved in the undate label.
         """
         if not value:
             raise ValueError("Parsing empty string is not supported")
@@ -54,14 +54,14 @@ class HijriDateConverter(BaseCalendarConverter):
         # parse the input string, then transform to undate object
         try:
             # parse the string with our Hijri date parser
-            parsetree = hijri_parser.parse(value)
+            parsetree = islamic_parser.parse(value)
             # transform the parse tree into an undate or undate interval
             undate_obj = self.transformer.transform(parsetree)
             # set the original date as a label, with the calendar name
             undate_obj.label = f"{value} {self.calendar_name}"
             return undate_obj
         except UnexpectedCharacters as err:
-            raise ValueError(f"Could not parse '{value}' as a Hijri date") from err
+            raise ValueError(f"Could not parse '{value}' as an Islamic date") from err
 
     # do we need to support conversion the other direction?
     # i.e., generate a Hijri date from an abitrary undate or undate interval?

--- a/src/undate/converters/calendars/islamic/converter.py
+++ b/src/undate/converters/calendars/islamic/converter.py
@@ -53,7 +53,7 @@ class IslamicDateConverter(BaseCalendarConverter):
 
         # parse the input string, then transform to undate object
         try:
-            # parse the string with our Hijri date parser
+            # parse the string with our Islamic Hijri date parser
             parsetree = islamic_parser.parse(value)
             # transform the parse tree into an undate or undate interval
             undate_obj = self.transformer.transform(parsetree)
@@ -64,4 +64,4 @@ class IslamicDateConverter(BaseCalendarConverter):
             raise ValueError(f"Could not parse '{value}' as an Islamic date") from err
 
     # do we need to support conversion the other direction?
-    # i.e., generate a Hijri date from an abitrary undate or undate interval?
+    # i.e., generate an Islamic Hijri date from an arbitrary undate or undate interval?

--- a/src/undate/converters/calendars/islamic/islamic.lark
+++ b/src/undate/converters/calendars/islamic/islamic.lark
@@ -3,7 +3,7 @@
 
 // only support day month year format for now
 // parser requires numeric day and year to be distinguished based on order
-hijri_date: day month year | month year | year
+islamic_date: day month year | month year | year
 
 // TODO: handle date ranges?
 

--- a/src/undate/converters/calendars/islamic/parser.py
+++ b/src/undate/converters/calendars/islamic/parser.py
@@ -1,0 +1,9 @@
+import pathlib
+
+from lark import Lark
+
+grammar_path = pathlib.Path(__file__).parent / "islamic.lark"
+
+with open(grammar_path) as grammar:
+    # NOTE: LALR parser is faster but can't be used due to ambiguity between years and days
+    islamic_parser = Lark(grammar.read(), start="islamic_date", strict=True)

--- a/src/undate/converters/calendars/islamic/transformer.py
+++ b/src/undate/converters/calendars/islamic/transformer.py
@@ -3,17 +3,17 @@ from lark import Transformer, Tree
 from undate import Undate, Calendar
 
 
-class HijriUndate(Undate):
-    """Undate convience subclass; sets default calendar to Hijri."""
+class IslamicUndate(Undate):
+    """Undate convience subclass; sets default calendar to Islamic."""
 
-    calendar = Calendar.HIJRI
+    calendar = Calendar.ISLAMIC
 
 
-class HijriDateTransformer(Transformer):
-    """Transform a Hijri date parse tree and return an Undate or
+class IslamicDateTransformer(Transformer):
+    """Transform an Islamic Hijri date parse tree and return an Undate or
     UndateInterval."""
 
-    def hijri_date(self, items):
+    def islamic_date(self, items):
         parts = {}
         for child in items:
             if child.data in ["year", "month", "day"]:
@@ -24,7 +24,7 @@ class HijriDateTransformer(Transformer):
 
         # initialize and return an undate with islamic year, month, day and
         # islamic calendar
-        return HijriUndate(**parts)
+        return IslamicUndate(**parts)
 
     # year translation is not needed since we want a tree with name year
     # this is equivalent to a no-op

--- a/src/undate/undate.py
+++ b/src/undate/undate.py
@@ -27,8 +27,8 @@ class Calendar(StrEnum):
     """Supported calendars"""
 
     GREGORIAN = auto()
-    HIJRI = auto()
     HEBREW = auto()
+    ISLAMIC = auto()
 
     @staticmethod
     def get_converter(calendar):

--- a/tests/test_converters/test_base.py
+++ b/tests/test_converters/test_base.py
@@ -5,7 +5,7 @@ from undate.converters.base import BaseDateConverter, BaseCalendarConverter
 from undate.converters.calendars import (
     GregorianDateConverter,
     HebrewDateConverter,
-    HijriDateConverter,
+    IslamicDateConverter,
 )
 
 
@@ -36,12 +36,12 @@ class TestBaseDateConverter:
 
     def test_subclasses(self):
         # define a nested subclass
-        class SubSubConverter(HijriDateConverter):
+        class SubSubConverter(IslamicDateConverter):
             pass
 
         subclasses = BaseDateConverter.subclasses()
         assert BaseCalendarConverter not in subclasses
-        assert HijriDateConverter in subclasses
+        assert IslamicDateConverter in subclasses
         assert HebrewDateConverter in subclasses
         assert GregorianDateConverter in subclasses
         assert SubSubConverter in subclasses

--- a/tests/test_converters/test_calendars/test_islamic/test_islamic_converter.py
+++ b/tests/test_converters/test_calendars/test_islamic/test_islamic_converter.py
@@ -1,40 +1,40 @@
 import pytest
 
-from undate.converters.calendars import HijriDateConverter
-from undate.converters.calendars.hijri.transformer import HijriUndate
+from undate.converters.calendars import IslamicDateConverter
+from undate.converters.calendars.islamic.transformer import IslamicUndate
 from undate.undate import Calendar, Undate
 from undate.date import DatePrecision, Date
 
 
-class TestHijriDateConverter:
+class TestIslamicDateConverter:
     def test_parse(self):
         # day
         # Monday, 7 Jumādā I 1243 Hijrī (26 November, 1827 CE); Jumada I = month 5
         date_str = "7 Jumādā I 1243"
-        date = HijriDateConverter().parse(date_str)
-        assert date == HijriUndate(1243, 5, 7)
-        assert date.calendar == Calendar.HIJRI
+        date = IslamicDateConverter().parse(date_str)
+        assert date == IslamicUndate(1243, 5, 7)
+        assert date.calendar == Calendar.ISLAMIC
         assert date.precision == DatePrecision.DAY
-        assert date.label == f"{date_str} {HijriDateConverter.calendar_name}"
+        assert date.label == f"{date_str} {IslamicDateConverter.calendar_name}"
 
         # month
         date_str = "Rajab 495"
-        date = HijriDateConverter().parse(date_str)
-        assert date == HijriUndate(495, 7)  # Rajab is month 7
-        assert date.calendar == Calendar.HIJRI
+        date = IslamicDateConverter().parse(date_str)
+        assert date == IslamicUndate(495, 7)  # Rajab is month 7
+        assert date.calendar == Calendar.ISLAMIC
         assert date.precision == DatePrecision.MONTH
-        assert date.label == f"{date_str} {HijriDateConverter.calendar_name}"
+        assert date.label == f"{date_str} {IslamicDateConverter.calendar_name}"
         # Gregorian earliest/ latest
         assert date.earliest == Date(1102, 4, 28)
         assert date.latest == Date(1102, 5, 27)
 
         # year
         date_str = "441"
-        date = HijriDateConverter().parse(date_str)
-        assert date == HijriUndate(441)
-        assert date.calendar == Calendar.HIJRI
+        date = IslamicDateConverter().parse(date_str)
+        assert date == IslamicUndate(441)
+        assert date.calendar == Calendar.ISLAMIC
         assert date.precision == DatePrecision.YEAR
-        assert date.label == f"{date_str} {HijriDateConverter.calendar_name}"
+        assert date.label == f"{date_str} {IslamicDateConverter.calendar_name}"
         # Gregorian earliest/ latest
         assert date.earliest == Date(1049, 6, 11)
         assert date.latest == Date(1050, 5, 31)
@@ -43,108 +43,108 @@ class TestHijriDateConverter:
         # earliest/latest should be converted to Gregorian for comparison
 
         # Monday, 7 Jumādā I 1243 Hijrī (26 November, 1827 CE); Jumada I = month 5
-        date = HijriUndate(1243, 5, 7)
+        date = IslamicUndate(1243, 5, 7)
         assert date.earliest == Date(1827, 11, 26)
         assert date.latest == Date(1827, 11, 26)
 
         # Jumādā I 1243 : 1827-11-20 to 1827-12-19
-        date = HijriUndate(1243, 5)
+        date = IslamicUndate(1243, 5)
         assert date.earliest == Date(1827, 11, 20)
         assert date.latest == Date(1827, 12, 19)
 
         # Rajab 495: 1102-04-28 to 1102-05-27 (Rajab = month 7)
-        date = HijriUndate(495, 7)
+        date = IslamicUndate(495, 7)
         assert date.earliest == Date(1102, 4, 28)
         assert date.latest == Date(1102, 5, 27)
 
         # 441 : 1049-06-11 to 1050-05-31
-        date = HijriUndate(441)
+        date = IslamicUndate(441)
         assert date.earliest == Date(1049, 6, 11)
         assert date.latest == Date(1050, 5, 31)
 
         # examples from ISMI data (reformatted to day month year)
         # 14 Rabīʿ I 901 : 1495-12-11 (Rabi 1 = month 3 )
-        date = HijriUndate(901, 3, 14)
+        date = IslamicUndate(901, 3, 14)
         assert date.earliest == Date(1495, 12, 11)
         assert date.latest == Date(1495, 12, 11)
 
         # 884 : 1479-04-03 to 1480-03-21
-        date = HijriUndate(884)
+        date = IslamicUndate(884)
         assert date.earliest == Date(1479, 4, 3)
         assert date.latest == Date(1480, 3, 21)
 
     def test_parse_error(self):
         # a string we can't parse should raise an error
         with pytest.raises(ValueError):
-            HijriDateConverter().parse("January 2, 1991")
+            IslamicDateConverter().parse("January 2, 1991")
         # empty string should also error
         with pytest.raises(ValueError):
-            HijriDateConverter().parse("")
+            IslamicDateConverter().parse("")
 
     def test_partially_known(self):
         # hijri dates get existing partially unknown behavior
-        unknown_month = HijriUndate(1243, "XX")
+        unknown_month = IslamicUndate(1243, "XX")
         assert unknown_month.precision == DatePrecision.MONTH
         assert unknown_month.earliest == Date(
-            *HijriDateConverter().to_gregorian(1243, 1, 1)
+            *IslamicDateConverter().to_gregorian(1243, 1, 1)
         )
         assert unknown_month.latest == Date(
-            *HijriDateConverter().to_gregorian(1243, 12, 30)
+            *IslamicDateConverter().to_gregorian(1243, 12, 30)
         )
 
-        partially_unknown_month = HijriUndate(1243, "1X")
+        partially_unknown_month = IslamicUndate(1243, "1X")
         assert partially_unknown_month.precision == DatePrecision.MONTH
         assert partially_unknown_month.earliest == Date(
-            *HijriDateConverter().to_gregorian(1243, 10, 1)
+            *IslamicDateConverter().to_gregorian(1243, 10, 1)
         )
         assert partially_unknown_month.latest == Date(
-            *HijriDateConverter().to_gregorian(1243, 12, 30)
+            *IslamicDateConverter().to_gregorian(1243, 12, 30)
         )
 
-        unknown_day = HijriUndate(1243, 2, "XX")
+        unknown_day = IslamicUndate(1243, 2, "XX")
         assert unknown_day.precision == DatePrecision.DAY
         assert unknown_day.earliest == Date(
-            *HijriDateConverter().to_gregorian(1243, 2, 1)
+            *IslamicDateConverter().to_gregorian(1243, 2, 1)
         )
         # second month has 29 days
         assert unknown_day.latest == Date(
-            *HijriDateConverter().to_gregorian(1243, 2, 29)
+            *IslamicDateConverter().to_gregorian(1243, 2, 29)
         )
-        partially_unknown_day = HijriUndate(1243, 2, "2X")
+        partially_unknown_day = IslamicUndate(1243, 2, "2X")
         assert partially_unknown_day.precision == DatePrecision.DAY
         assert partially_unknown_day.earliest == Date(
-            *HijriDateConverter().to_gregorian(1243, 2, 20)
+            *IslamicDateConverter().to_gregorian(1243, 2, 20)
         )
         assert partially_unknown_day.latest == Date(
-            *HijriDateConverter().to_gregorian(1243, 2, 29)
+            *IslamicDateConverter().to_gregorian(1243, 2, 29)
         )
 
     def test_compare_across_calendars(self):
         # only day-precision dates can be exactly equal across calendars
 
         # 7 Jumādā I 1243 Hijrī : 26 November, 1827; Jumada I = month 5
-        assert HijriUndate(1243, 5, 7) == Undate(1827, 11, 26)
+        assert IslamicUndate(1243, 5, 7) == Undate(1827, 11, 26)
         # 14 Rabīʿ I 901 : 1495-12-11 (Rabi 1 = month 3 )
-        assert HijriUndate(901, 3, 14) == Undate(1495, 12, 11)
+        assert IslamicUndate(901, 3, 14) == Undate(1495, 12, 11)
 
         # greater than / less than
-        assert HijriUndate(901) < Undate(1500)
-        assert HijriUndate(901) > Undate(1450)
+        assert IslamicUndate(901) < Undate(1500)
+        assert IslamicUndate(901) > Undate(1450)
         # Jumādā I 1243 : 1827-11-20 to 1827-12-19
-        assert HijriUndate(1243, 5) > Undate(1827, 10)
-        assert HijriUndate(1243, 5) < Undate(1828, 1)
+        assert IslamicUndate(1243, 5) > Undate(1827, 10)
+        assert IslamicUndate(1243, 5) < Undate(1828, 1)
 
         # 7 Jumādā I 1243 Hijrī : 26 November, 1827, so it falls
         # within (or is contained by) November 1827
-        assert HijriUndate(1243, 5, 7) in Undate(1827, 11)
-        assert HijriUndate(1243, 5, 7) not in Undate(1827, 10)
+        assert IslamicUndate(1243, 5, 7) in Undate(1827, 11)
+        assert IslamicUndate(1243, 5, 7) not in Undate(1827, 10)
 
         # sorting
         sorted_dates = sorted(
             [
-                HijriUndate(884),  # 1479 to 1480 Gregorian
-                HijriUndate(441),  # 1049 to 1050 Gregorian
-                HijriUndate(901),  # 1495 to 1495 Gregorian
+                IslamicUndate(884),  # 1479 to 1480 Gregorian
+                IslamicUndate(441),  # 1049 to 1050 Gregorian
+                IslamicUndate(901),  # 1495 to 1495 Gregorian
                 Undate(1995),
                 Undate(33),
                 Undate(1350),

--- a/tests/test_converters/test_calendars/test_islamic/test_islamic_parser.py
+++ b/tests/test_converters/test_calendars/test_islamic/test_islamic_parser.py
@@ -1,5 +1,5 @@
 import pytest
-from undate.converters.calendars.hijri.parser import hijri_parser
+from undate.converters.calendars.islamic.parser import islamic_parser
 
 
 # for now, just test that valid dates can be parsed
@@ -49,7 +49,7 @@ testcases = [
 
 @pytest.mark.parametrize("date_string", testcases)
 def test_should_parse(date_string):
-    assert hijri_parser.parse(date_string)
+    assert islamic_parser.parse(date_string)
 
 
 error_cases = [
@@ -73,4 +73,4 @@ error_cases = [
 @pytest.mark.parametrize("date_string", error_cases)
 def test_should_error(date_string):
     with pytest.raises(Exception):
-        hijri_parser.parse(date_string)
+        islamic_parser.parse(date_string)

--- a/tests/test_converters/test_calendars/test_islamic/test_islamic_transformer.py
+++ b/tests/test_converters/test_calendars/test_islamic/test_islamic_transformer.py
@@ -1,34 +1,34 @@
 import pytest
-from undate.converters.calendars.hijri.parser import hijri_parser
-from undate.converters.calendars.hijri.transformer import (
-    HijriDateTransformer,
-    HijriUndate,
+from undate.converters.calendars.islamic.parser import islamic_parser
+from undate.converters.calendars.islamic.transformer import (
+    IslamicDateTransformer,
+    IslamicUndate,
 )
 from undate.undate import Undate, Calendar
 from undate.date import DatePrecision
 
 
-def test_hijri_undate():
-    assert HijriUndate(848).calendar == Calendar.HIJRI
+def test_islamic_undate():
+    assert IslamicUndate(848).calendar == Calendar.ISLAMIC
 
 
 testcases = [
     # examples from Princeton Geniza Project
     # date conversions checked with https://www.muqawwim.com/
     # Monday, 7 Jumādā I 1243 Hijrī (26 November, 1827 CE); Jumada I = month 5
-    ("7 Jumādā I 1243", HijriUndate(1243, 5, 7), DatePrecision.DAY),
-    ("Jumādā I 1243", HijriUndate(1243, 5), DatePrecision.MONTH),
-    ("1243", HijriUndate(1243), DatePrecision.YEAR),
+    ("7 Jumādā I 1243", IslamicUndate(1243, 5, 7), DatePrecision.DAY),
+    ("Jumādā I 1243", IslamicUndate(1243, 5), DatePrecision.MONTH),
+    ("1243", IslamicUndate(1243), DatePrecision.YEAR),
     # Gregorian:  UndateInterval(Undate(1827, 7, 25), Undate(1828, 7, 13)),
     # Zū al-Qaʿdah / Dhu l-Qa'da = month 11
-    ("27 Dhū l-Qaʿda 632", HijriUndate(632, 11, 27), DatePrecision.DAY),
+    ("27 Dhū l-Qaʿda 632", IslamicUndate(632, 11, 27), DatePrecision.DAY),
     # Rajab = month 7
-    ("Rajab 495", HijriUndate(495, 7), DatePrecision.MONTH),
-    ("441", HijriUndate(441), DatePrecision.YEAR),
+    ("Rajab 495", IslamicUndate(495, 7), DatePrecision.MONTH),
+    ("441", IslamicUndate(441), DatePrecision.YEAR),
     # examples from ISMI data (reformatted to day month year)
     # Rabi 1 = month 3
-    ("14 Rabīʿ I 901", HijriUndate(901, 3, 14), DatePrecision.DAY),
-    ("884", HijriUndate(884), DatePrecision.YEAR),
+    ("14 Rabīʿ I 901", IslamicUndate(901, 3, 14), DatePrecision.DAY),
+    ("884", IslamicUndate(884), DatePrecision.YEAR),
     # Gregorian:  UndateInterval(Undate(1479, 4, 3), Undate(1480, 3, 21)),
     # add when we support parsing ranges:
     # 900 Muḥarram 1 - 999 Ḏu al-Ḥijjaẗ 29 : 1494-10-11 to 1591-10-18
@@ -37,9 +37,9 @@ testcases = [
 
 @pytest.mark.parametrize("date_string,expected,expected_precision", testcases)
 def test_transform(date_string, expected, expected_precision):
-    transformer = HijriDateTransformer(visit_tokens=True)
+    transformer = IslamicDateTransformer(visit_tokens=True)
     # parse the input string, then transform to undate object
-    parsetree = hijri_parser.parse(date_string)
+    parsetree = islamic_parser.parse(date_string)
     transformed_date = transformer.transform(parsetree)
     assert transformed_date == expected
     # currently only undates have date precision

--- a/tests/test_undate.py
+++ b/tests/test_undate.py
@@ -31,7 +31,7 @@ class TestUndate:
             repr(Undate(2022, 11, 7, label="A Special Day"))
             == "<Undate 'A Special Day' 2022-11-07 (Gregorian)>"
         )
-        assert repr(Undate(484, calendar=Calendar.HIJRI)) == "<Undate 0484 (Hijri)>"
+        assert repr(Undate(484, calendar=Calendar.ISLAMIC)) == "<Undate 0484 (Islamic)>"
 
     def test_init_str(self):
         assert Undate("2000").earliest.year == 2000
@@ -122,10 +122,10 @@ class TestUndate:
     def test_calendar(self):
         assert Undate(2024).calendar == Calendar.GREGORIAN
         # by name, any case
-        assert Undate(848, calendar="HIJRI").calendar == Calendar.HIJRI
-        assert Undate(848, calendar="hijri").calendar == Calendar.HIJRI
+        assert Undate(848, calendar="ISLAMIC").calendar == Calendar.ISLAMIC
+        assert Undate(848, calendar="islamic").calendar == Calendar.ISLAMIC
         # by enum
-        assert Undate(848, calendar=Calendar.HIJRI).calendar == Calendar.HIJRI
+        assert Undate(848, calendar=Calendar.ISLAMIC).calendar == Calendar.ISLAMIC
         # invalid
         with pytest.raises(ValueError, match="Calendar `foobar` is not supported"):
             Undate(848, calendar="foobar")


### PR DESCRIPTION
resolves #120 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity and consistency in calendar terminology across user documentation.
- **Refactor**
	- Updated calendar conversion components by renaming user-facing identifiers from "Hijri" to "Islamic" for more accurate representation.
	- Adjusted parsing rules and public interfaces to align with the revised terminology.
- **Tests**
	- Updated test cases to validate and reflect the new Islamic naming conventions, ensuring consistent functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->