### PR TITLE
Implement UnInt and UnDelta for uncertain date durations

### DIFF
--- a/src/undate/converters/calendars/gregorian.py
+++ b/src/undate/converters/calendars/gregorian.py
@@ -13,8 +13,10 @@ class GregorianDateConverter(BaseCalendarConverter):
     #: calendar
     calendar_name: str = "Gregorian"
 
-    #: known non-leap year
+    #: arbitrary known non-leap year
     NON_LEAP_YEAR: int = 2022
+    #: arbitrary known leap year
+    LEAP_YEAR: int = 2024
 
     def min_month(self) -> int:
         """First month for the Gregorian calendar."""
@@ -38,6 +40,7 @@ class GregorianDateConverter(BaseCalendarConverter):
             _, max_day = monthrange(year, month)
         else:
             # if year and month are unknown, return maximum possible
+            # TODO: should this return an IntervalRange?
             max_day = 31
 
         return max_day

--- a/src/undate/date.py
+++ b/src/undate/date.py
@@ -33,6 +33,13 @@ class Timedelta(np.ndarray):
 
 @dataclass
 class UnInt:
+    """An uncertain integer intended for use with uncertain durations (:class:`UnDelta`),
+    to convey a range of possible integer values between an upper
+    and lower bound (inclusive). Supports comparison, addition and subtraction,
+    checking if a value is included in the range, and iterating over numbers
+    included in the range.
+    """
+
     lower: int
     upper: int
 

--- a/src/undate/date.py
+++ b/src/undate/date.py
@@ -1,7 +1,9 @@
 from enum import IntEnum
+from dataclasses import dataclass, replace
+import operator
 
 # Pre 3.10 requires Union for multiple types, e.g. Union[int, None] instead of int | None
-from typing import Optional, Union
+from typing import Optional, Union, Iterable
 
 import numpy as np
 
@@ -27,6 +29,139 @@ class Timedelta(np.ndarray):
     def days(self) -> int:
         """number of days, as an integer"""
         return int(self.astype("datetime64[D]").astype("int"))
+
+
+@dataclass
+class UnInt:
+    lower: int
+    upper: int
+
+    def __post_init__(self):
+        # validate that lower value is less than upper
+        if not self.lower < self.upper:
+            raise ValueError(
+                f"Lower value ({self.lower}) must be less than upper ({self.upper})"
+            )
+
+    def __iter__(self) -> Iterable:
+        # yield all integers in range from lower to upper, inclusive
+        yield from range(self.lower, self.upper + 1)
+
+    def __gt__(self, other: object) -> bool:
+        match other:
+            case int():
+                return self.upper > other
+            case UnInt():
+                return self.upper > other.lower
+            case _:
+                return NotImplemented
+
+    def __lt__(self, other: object) -> bool:
+        match other:
+            case int():
+                return self.upper < other
+            case UnInt():
+                return self.upper < other.lower
+            case _:
+                return NotImplemented
+
+    def __contains__(self, other: object) -> bool:
+        match other:
+            case int():
+                return other >= self.lower and other <= self.upper
+            case UnInt():
+                return other.lower >= self.lower and other.upper <= self.upper
+            case _:
+                # unsupported type: return false
+                return False
+
+    def _replace_with(self, other_lower, other_upper, op):
+        """Create and return a new instance of UnInt using the specified
+        operator (e.g. add, subtract) and other values to modify the values in
+        the current UnInt instance."""
+        return replace(
+            self, lower=op(self.lower, other_lower), upper=op(self.upper, other_upper)
+        )
+
+    def __add__(self, other: object) -> bool:
+        match other:
+            case int():
+                # increase both values by the added amount
+                add_values = (other, other)
+            case UnInt():
+                # subtract the upper and lower values by the other lower and upper
+                # to include the largest range of possible values
+                # (when calculating with uncertain values, the uncertainty increases)
+                add_values = (other.lower, other.upper)
+            case _:
+                return NotImplemented
+
+        return self._replace_with(*add_values, operator.add)
+
+    def __sub__(self, other):
+        match other:
+            case int():
+                # decrease both values by the subtracted amount
+                sub_values = (other, other)
+            case UnInt():
+                # to determine the largest range of possible values,
+                # subtract the other upper value from current lower
+                # and other lower value from current upper
+                sub_values = (other.upper, other.lower)
+            case _:
+                return NotImplemented
+
+        return self._replace_with(*sub_values, operator.sub)
+
+
+@dataclass
+class UnDelta:
+    """
+    An uncertain timedelta, for durations where the number of days is uncertain.
+    Initialize with a list of possible durations in days as integers, which are used
+    to calculate a value for duration in :attr:`days` as an
+    instance of :class:`UnInt`.
+    """
+
+    # NOTE: we will probably need other timedelta-like logic here besides days...
+
+    #: possible durations days, as an instance of :class:`UnInt`
+    days: UnInt
+
+    def __init__(self, *days: int):
+        if len(days) < 2:
+            raise ValueError(
+                "Must specify at least two values for an uncertain duration"
+            )
+        self.days = UnInt(min(days), max(days))
+
+    def __repr__(self):
+        # customize string representation  for simpler notation; default
+        # specifies full UnInt initialization with upper and lower keywords
+        return f"{self.__class__.__name__}(days=[{self.days.lower},{self.days.upper}])"
+
+    # TODO: what does equality for an uncertain range mean?
+    # is an uncertain range ever equal to another uncertain range?
+
+    def __eq__(self, other: object) -> bool:
+        # is an uncertain duration ever *equal* another, even if the values are the same?
+        if other is self:
+            return True
+        return False
+
+    def __lt__(self, other: object) -> bool:
+        match other:
+            case Timedelta() | UnDelta():
+                return self.days < other.days
+            case _:
+                return NotImplemented
+
+    def __gt__(self, other: object) -> bool:
+        match other:
+            case Timedelta() | UnDelta():
+                return self.days > other.days
+            case _:
+                return NotImplemented
 
 
 #: timedelta for single day

--- a/src/undate/date.py
+++ b/src/undate/date.py
@@ -35,7 +35,7 @@ class Timedelta(np.ndarray):
 class UnInt:
     """An uncertain integer intended for use with uncertain durations (:class:`UnDelta`),
     to convey a range of possible integer values between an upper
-    and lower bound (inclusive). Supports comparison, addition and subtraction,
+    and lower bound (both inclusive). Supports comparison, addition and subtraction,
     checking if a value is included in the range, and iterating over numbers
     included in the range.
     """

--- a/src/undate/date.py
+++ b/src/undate/date.py
@@ -57,9 +57,9 @@ class UnInt:
     def __gt__(self, other: object) -> bool:
         match other:
             case int():
-                return self.upper > other
+                return self.lower > other
             case UnInt():
-                return self.upper > other.lower
+                return self.lower > other.upper
             case _:
                 return NotImplemented
 
@@ -90,14 +90,14 @@ class UnInt:
             self, lower=op(self.lower, other_lower), upper=op(self.upper, other_upper)
         )
 
-    def __add__(self, other: object) -> bool:
+    def __add__(self, other: object) -> "UnInt":
         match other:
             case int():
                 # increase both values by the added amount
                 add_values = (other, other)
             case UnInt():
-                # subtract the upper and lower values by the other lower and upper
-                # to include the largest range of possible values
+                # add other lower value to current lower and other upper
+                # to current upper to include the largest range of possible values
                 # (when calculating with uncertain values, the uncertainty increases)
                 add_values = (other.lower, other.upper)
             case _:
@@ -105,7 +105,7 @@ class UnInt:
 
         return self._replace_with(*add_values, operator.add)
 
-    def __sub__(self, other):
+    def __sub__(self, other) -> "UnInt":
         match other:
             case int():
                 # decrease both values by the subtracted amount
@@ -147,14 +147,12 @@ class UnDelta:
         # specifies full UnInt initialization with upper and lower keywords
         return f"{self.__class__.__name__}(days=[{self.days.lower},{self.days.upper}])"
 
-    # TODO: what does equality for an uncertain range mean?
-    # is an uncertain range ever equal to another uncertain range?
-
     def __eq__(self, other: object) -> bool:
         # is an uncertain duration ever *equal* another, even if the values are the same?
-        if other is self:
-            return True
-        return False
+        # for now, make the assumption that we only want identity equality
+        # and not value equality; perhaps in future we can revisit
+        # or add functions to check value equality / equivalence / similarity
+        return other is self
 
     def __lt__(self, other: object) -> bool:
         match other:

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -123,13 +123,13 @@ class TestUnInt:
     def test_gt(self):
         ten_twelve = UnInt(10, 12)
         # compare with integer
-        assert 13 > ten_twelve
-        assert not 12 > ten_twelve
-        assert not 9 > ten_twelve
+        assert ten_twelve > 9
+        assert not ten_twelve > 12
+        assert not ten_twelve > 15
         # compare with unint
-        assert UnInt(13, 23) > ten_twelve
-        assert not UnInt(12, 24) > ten_twelve
-        assert not UnInt(2, 4) > ten_twelve
+        assert ten_twelve > UnInt(2, 4)
+        assert not ten_twelve > UnInt(12, 24)
+        assert not ten_twelve > UnInt(13, 23)
         # unsupported type
         with pytest.raises(TypeError):
             ten_twelve > "three"
@@ -137,13 +137,13 @@ class TestUnInt:
     def test_lt(self):
         ten_twelve = UnInt(10, 12)
         # compare with integer
-        assert 9 < ten_twelve
-        assert not 12 < ten_twelve
-        assert not 13 < ten_twelve
+        assert ten_twelve < 13
+        assert not ten_twelve < 12
+        assert not ten_twelve < 9
         # compare with unint
-        assert UnInt(2, 4) < ten_twelve
-        assert not UnInt(12, 24) < ten_twelve
-        assert not UnInt(13, 23) < ten_twelve
+        assert ten_twelve < UnInt(13, 23)
+        assert not ten_twelve < UnInt(12, 24)
+        assert not ten_twelve < UnInt(2, 4)
         # unsupported type
         with pytest.raises(TypeError):
             ten_twelve < "three"

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -120,6 +120,34 @@ class TestUnInt:
         # other types are assumed not in range
         assert "twenty-eight" not in anymonth_days
 
+    def test_gt(self):
+        ten_twelve = UnInt(10, 12)
+        # compare with integer
+        assert 13 > ten_twelve
+        assert not 12 > ten_twelve
+        assert not 9 > ten_twelve
+        # compare with unint
+        assert UnInt(13, 23) > ten_twelve
+        assert not UnInt(12, 24) > ten_twelve
+        assert not UnInt(2, 4) > ten_twelve
+        # unsupported type
+        with pytest.raises(TypeError):
+            ten_twelve > "three"
+
+    def test_lt(self):
+        ten_twelve = UnInt(10, 12)
+        # compare with integer
+        assert 9 < ten_twelve
+        assert not 12 < ten_twelve
+        assert not 13 < ten_twelve
+        # compare with unint
+        assert UnInt(2, 4) < ten_twelve
+        assert not UnInt(12, 24) < ten_twelve
+        assert not UnInt(13, 23) < ten_twelve
+        # unsupported type
+        with pytest.raises(TypeError):
+            ten_twelve < "three"
+
     def test_iterable(self):
         anymonth_days = UnInt(lower=28, upper=31)
         assert list(anymonth_days) == [28, 29, 30, 31]

--- a/tests/test_undate.py
+++ b/tests/test_undate.py
@@ -4,7 +4,7 @@ import pytest
 
 from undate import Undate, UndateInterval, Calendar
 from undate.converters.base import BaseCalendarConverter
-from undate.date import Date, DatePrecision, Timedelta
+from undate.date import Date, DatePrecision, Timedelta, UnDelta, UnInt
 
 
 class TestUndate:
@@ -404,10 +404,23 @@ class TestUndate:
         # month in unknown year
         assert Undate(month=6).duration().days == 30
         # partially known month
-        assert Undate(year=1900, month="1X").duration().days == 31
-        # what about february?
-        # could vary with leap years, but assume non-leapyear
-        assert Undate(month=2).duration().days == 28
+        # 1X = October, November, or December = 30 or 31 days
+        # should return a Undelta object
+        unknown_month_duration = Undate(year=1900, month="1X").duration()
+        assert isinstance(unknown_month_duration, UnDelta)
+        assert unknown_month_duration.days == UnInt(30, 31)
+
+        # completely unknown month should also return a Undelta object
+        unknown_month_duration = Undate(year=1900, month="XX").duration()
+        assert isinstance(unknown_month_duration, UnDelta)
+        # possible range is 28 to 31 days
+        assert unknown_month_duration.days == UnInt(28, 31)
+
+        # the number of days in February of an unknown year is uncertain, since
+        # it could vary with leap years; either 28 or 29 days
+        feb_duration = Undate(month=2).duration()
+        assert isinstance(feb_duration, UnDelta)
+        assert feb_duration.days == UnInt(28, 29)
 
     def test_known_year(self):
         assert Undate(2022).known_year is True


### PR DESCRIPTION
Based on previous experiments with [uncertainties](https://github.com/dh-tech/undate-python/pull/116) and [portion](https://github.com/dh-tech/undate-python/pull/128) libraries and feedback from @taylor-arnold

Changes in this PR:
- `UnInt` dataclass for range of uncertain integer values
- `UnDelta` dataclass for uncertain timedelta (datedelta); uses `UnInt` for duration in days
- update `UnDate` class to return uncertain delta for some durations (not yet used in all cases where it should be)
- unit tests for associated classes and methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for uncertain durations and integer ranges, allowing representation of ambiguous date and time intervals.
  - Added new classes to handle uncertain integer ranges and durations.

- **Bug Fixes**
  - Improved duration calculations for partially known or ambiguous months and years, now accurately reflecting leap year and month variability.

- **Tests**
  - Added comprehensive tests for uncertain integer and duration classes.
  - Enhanced tests for partially known date durations to verify correct handling of uncertainty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->