### PR TITLE
Setup for optional django dependency and unit testing with/without django

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13"]
-        django: [0, "5.2"]  # add more versions as we add support
+        django: ["NO_DJANGO", "5.2"]  # add more versions as we add support
       # exclude incompatible python+django combinations if needed
       # OR limit django+python to specific combinations to avoid too many builds
     defaults:
@@ -46,7 +46,7 @@ jobs:
       # test with and without django based on build matrix
       - name: Install package with dependencies (and optionally django)
         run: |
-          if [ "${{ matrix.django }}" -gt "0"]; then pip install -q Django==${{ matrix.django }} pytest-django; fi
+          if [ "${{ matrix.django }}" != "NO_DJANGO"]; then pip install -q Django==${{ matrix.django }} pytest-django; fi
           pip install -e '.[test]'
 
       # for all versions but the one we use for code coverage, run normally

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -25,6 +25,9 @@ jobs:
     strategy:
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13"]
+        django: [0, "5.2"]  # add more versions as we add support
+      # exclude incompatible python+django combinations if needed
+      # OR limit django+python to specific combinations to avoid too many builds
     defaults:
       run:
         working-directory: .
@@ -40,8 +43,11 @@ jobs:
           cache: 'pip'
           cache-dependency-path: '**/pyproject.toml'
 
-      - name: Install package with dependencies
-        run: pip install -e ".[test]"
+      # test with and without django based on build matrix
+      - name: Install package with dependencies (and optionally django)
+        run: |
+          if [ "${{ matrix.django }}" -gt "0"]; then pip install -q Django==${{ matrix.django }} pytest-django; fi
+          pip install -e '.[test]'
 
       # for all versions but the one we use for code coverage, run normally
       - name: Run unit tests without code coverage

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ Use the `@name` notation to specify the branch or tag; e.g., to install developm
 pip install git+https://github.com/dh-tech/undate-python@develop#egg=undate
 ```
 
+### Optional Django Support (PRELIMINARY / IN PROGRESS)
+
+To install with optional Django integration field support:
+```console
+pip install undate[django]
+```
+
+
 ## Example Usage
 
 Often humanities and cultural data include imprecise or uncertain

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Framework :: Django",
+    "Framework :: Django :: 5.2",    
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
@@ -53,6 +55,7 @@ classifiers = [
 
 [project.optional-dependencies]
 docs = ["sphinx>=7.0.0", "alabaster", "myst-parser", "myst-parser[linkify]"]
+django = ["django>=5.2"]
 test = ["pytest>=7.2", "pytest-ordering", "pytest-cov"]
 notebooks = ["jupyterlab", "pandas", "treon", "altair"]
 check = ["undate[docs]", "undate[notebooks]", "mypy", "ruff"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,13 @@ docs = ["sphinx>=7.0.0", "alabaster", "myst-parser", "myst-parser[linkify]"]
 django = ["django>=5.2"]
 test = ["pytest>=7.2", "pytest-ordering", "pytest-cov"]
 notebooks = ["jupyterlab", "pandas", "treon", "altair"]
-check = ["undate[docs]", "undate[notebooks]", "mypy", "ruff"]
+check = [
+    "undate[docs]",
+    "undate[notebooks]",
+    "mypy",
+    "ruff",
+    "pip>=25.3",
+]
 dev = [
     "pre-commit>=2.20.0",
     "twine",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,8 @@ docs = ["sphinx>=7.0.0", "alabaster", "myst-parser", "myst-parser[linkify]"]
 django = ["django>=5.2"]
 test = ["pytest>=7.2", "pytest-ordering", "pytest-cov"]
 notebooks = ["jupyterlab", "pandas", "treon", "altair"]
-check = ["undate[docs]", "undate[notebooks]", "mypy", "ruff"]
+# numpy 2.3+ needed for removal of deperecated typing plugin
+check = ["undate[docs]", "undate[notebooks]", "mypy", "ruff", "numpy>=2.3",]
 dev = [
     "pre-commit>=2.20.0",
     "twine",
@@ -90,6 +91,3 @@ markers = [
     "last : run marked tests after all others",
     "first : run marked tests before all others",
 ]
-
-[tool.mypy]
-plugins = ["numpy.typing.mypy_plugin"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,7 @@ docs = ["sphinx>=7.0.0", "alabaster", "myst-parser", "myst-parser[linkify]"]
 django = ["django>=5.2"]
 test = ["pytest>=7.2", "pytest-ordering", "pytest-cov"]
 notebooks = ["jupyterlab", "pandas", "treon", "altair"]
-# numpy 2.3+ needed for removal of deperecated typing plugin
-check = ["undate[docs]", "undate[notebooks]", "mypy", "ruff", "numpy>=2.3",]
+check = ["undate[docs]", "undate[notebooks]", "mypy", "ruff"]
 dev = [
     "pre-commit>=2.20.0",
     "twine",

--- a/src/undate/test_utils.py
+++ b/src/undate/test_utils.py
@@ -15,12 +15,14 @@ def test_django_functionality():
 """
 
 import pytest
+from types import ModuleType
 
+django: ModuleType | None = None
 try:
-    import django
+    import django  # type: ignore[import-not-found, no-redef]
 except ImportError:
-    django = None
+    pass
 
 skipif_no_django = pytest.mark.skipif(django is None, reason="requires Django")
 
-skipif_django = pytest.mark.skipif(django, reason="requires no Django")
+skipif_django = pytest.mark.skipif(django is not None, reason="requires no Django")

--- a/src/undate/test_utils.py
+++ b/src/undate/test_utils.py
@@ -1,0 +1,26 @@
+"""
+Utility decorators for unit tests that require django to be installed,
+or not installed. To use, import into unit test and apply
+to test method or class:
+
+```python
+
+from undate.test_utils import skipif_no_django, skipif_django
+
+@skipif_no_django
+def test_django_functionality():
+    ....
+```
+
+"""
+
+import pytest
+
+try:
+    import django
+except ImportError:
+    django = None
+
+skipif_no_django = pytest.mark.skipif(django is None, reason="requires Django")
+
+skipif_django = pytest.mark.skipif(django, reason="requires no Django")

--- a/tests/test_django/test_django_setup.py
+++ b/tests/test_django/test_django_setup.py
@@ -1,0 +1,16 @@
+try:
+    import django
+except ImportError:
+    django = None
+
+from undate.test_utils import skipif_no_django, skipif_django
+
+
+@skipif_no_django
+def test_django():
+    assert django is not None
+
+
+@skipif_django
+def test_no_django():
+    assert django is None


### PR DESCRIPTION
Resolves #152 

Changes in this PR:
- adds optional dependency group to pyproject.toml with django>5.2
- create initial / empty `undate.django` module
- update unit test build matrix to test without django and against django 5.2
- add test utility with pytest skip decorators for tests that require django is/is not installed (adapted from my https://github.com/Princeton-CDH/parasolr project)
- placeholder tests to confirm matrix build and decorators are working as expected

To check locally, if desired:
- running pytest with django installed should pass with one skipped test
- running pytest with django _not_ installed should also pass with one skipped test

## Questions &  notes:
- Should I add some notes about optional django integration to the developer notes document?
- I put the `test_utils` in the main package because the tests directory isn't currently setup as a python module, but it's seems a little awkward there (mypy check is failing, and it requires pytest, which is a dev/test requirement). Thoughts?
- parasolr also has a convenience `@requires_django` decorator, would that be useful to add? https://github.com/Princeton-CDH/parasolr/blob/main/parasolr/django/util.py 
- I will need to update the GitHub required checks for the revised build matrix once we are happy with the new build
- I will need to update codecov configuration - once we start adding optional tests, we no longer expect tests to have 100% coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional Django support to the package.

* **Documentation**
  * Added Django installation instructions to the README.

* **Chores**
  * Updated CI/CD workflow to test compatibility with and without Django.
  * Added Django as an optional dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->